### PR TITLE
chore(evm): Static gas consumption for precompiles (TEMPORARY).

### DIFF
--- a/x/evm/plugins/precompile/plugin.go
+++ b/x/evm/plugins/precompile/plugin.go
@@ -124,10 +124,11 @@ func (p *plugin) Run(
 
 	// run precompile container
 	ret, err := pc.Run(
-		ctx.
-			WithGasMeter(gm).
-			WithKVGasConfig(p.kvGasConfig).
-			WithTransientKVGasConfig(p.transientKVGasConfig),
+		ctx.WithGasMeter(gm),
+		// TODO: Re-enable gas config for precompiles.
+		// https://github.com/berachain/stargazer/issues/393
+		// WithKVGasConfig(p.kvGasConfig).
+		// WithTransientKVGasConfig(p.transientKVGasConfig),
 		input,
 		caller,
 		value,


### PR DESCRIPTION
Something is up with Estimate Gas and Precompiles, so to get things into a good state, we are temporarily disabling the cosmos gas consumption.