### PR TITLE
docs: Update querying-json-rpc.mdx with working code

### DIFF
--- a/docs/web/pages/docs/interacting-with-node/querying-json-rpc.mdx
+++ b/docs/web/pages/docs/interacting-with-node/querying-json-rpc.mdx
@@ -46,18 +46,19 @@ import (
 )
 
 func main() {
-    client, err := ethclient.Dial("<JSON_RPC_ENDPOINT>")
+    rpcEndpoint := "http://localhost:1317/eth/rpc" // default local node RPC Endpoint
+    client, err := ethclient.Dial(rpcEndpoint)
     if err != nil {
         log.Fatal(err)
     }
 
-    header, err := client.HeaderByNumber(nil, nil)
+    header, err := client.HeaderByNumber(context.Background(), nil)
     if err != nil {
         log.Fatal(err)
     }
 
-    blockNumber := header.Number.ToString()
-    fmt.Println(header.Number.String()) // 5671744
+    blockNumber := header.Number.String()
+    fmt.Println(blockNumber) // 5671744
 }
 ```
 


### PR DESCRIPTION
Small modifications to golang example to have working example when interacting with a local node via JSON-RPC.

Previous code had following issues:
- Didn't set a context on `client.HeaderByNumber` resulting in `net/http: nil Context` error. 
- Used `header.Number.ToString()` when correct method is `header.Number.String()`. 
- Didn't pass in `blockNumber` to `fmt.Println()` function

Nit: I prefer when I can copy paste example code and have it run so I hardcoded the RPC Endpoint for a local node

Tested by running local `polard` node on M1 Mac following instructions from `main` branch README.md 