### PR TITLE
refactor: Rename Polaris VM to Polaris Ethereum everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This meant that we had to built Polaris with serveral core principles in mind:
     .
     ├── build                   # Build scripts and utils
     ├── docs                    # Documentation files
-    ├── eth                     # The core Polaris VM implementation
+    ├── eth                     # The core Polaris Ethereum implementation
     ├── lib                     # Library files usable throughout the repo
     ├── host                     
     │   ├── cosmos              # A Cosmos integration of Polaris

--- a/docs/web/pages/docs/building-modules/creating-custom-modules.mdx
+++ b/docs/web/pages/docs/building-modules/creating-custom-modules.mdx
@@ -1,5 +1,5 @@
 # Creating Custom Modules
 Modules provide the modularity of any Cosmos chain. You can extend
-the use of modules on Polaris VM by following standard Cosmos SDK practices for
+the use of modules on Polaris Ethereum by following standard Cosmos SDK practices for
 adding new custom module. You can view more information about building 
 custom Cosmos SDK modules [here](https://docs.cosmos.network/main/building-modules/module-manager).

--- a/docs/web/pages/docs/building-modules/list-of-modules.mdx
+++ b/docs/web/pages/docs/building-modules/list-of-modules.mdx
@@ -1,9 +1,9 @@
 # Default Modules
 
-Polaris VM supports all of the default modules in cosmos. To view all of the default modules
+Polaris Ethereum supports all of the default modules in cosmos. To view all of the default modules
 please refer to the [List of Modules](https://docs.cosmos.network/main/modules) section of the Cosmos SDK documentation.
 
 
 ## EVM module
 
-Polaris VM introduces one custom module, the EVM module.
+Polaris Ethereum introduces one custom module, the EVM module.

--- a/docs/web/pages/docs/building-precompiles/intro-to-precompiles.mdx
+++ b/docs/web/pages/docs/building-precompiles/intro-to-precompiles.mdx
@@ -1,7 +1,7 @@
 # Introduction To Precompiled contracts
 
-Polaris VM's unique features rely heavily on its custom precompiled contracts. 
-How do precompiled contracts work in Ethereum, and what sets them apart from Polaris VM's implementation?
+Polaris Ethereum's unique features rely heavily on its custom precompiled contracts. 
+How do precompiled contracts work in Ethereum, and what sets them apart from Polaris Ethereum's implementation?
 
 ## What is a Precompiled Contract on Ethereum?
 
@@ -18,17 +18,17 @@ contracts on Ethereum include contracts that perform elliptic curve operations, 
 By using precompiled contracts, developers can save time and gas costs, as they don't have to deploy and compile their own version of the contract, and can rely 
 on the optimized version that is already installed on the network.
 
-## What is a Precompiled Contract on Polaris VM?
+## What is a Precompiled Contract on Polaris Ethereum?
 
-In Polaris VM, a precompiled contract is a custom piece of code that is pre-installed on the chain.
+In Polaris Ethereum, a precompiled contract is a custom piece of code that is pre-installed on the chain.
 Because it is pre-installed on the chain, it is able to have access to the cosmos-sdk application
 layer and consensus layer.
 
-This allows a precompiled contract on Polaris VM can be used to run
+This allows a precompiled contract on Polaris Ethereum can be used to run
 any arbitrary piece of code that is integrated into the node via the EVM. Precompiled contracts
 can be called like any other smart contract with a contract address and ABI to define behavior.
 
 
-The possibilities of a Polaris VM precompiled contract is only limited by the cosmos-sdk application layer and consensus layer.
-For information on how to interact with Polaris VM's precompiled contracts, view the [Precompile Overview](../precompile-overview) section.
+The possibilities of a Polaris Ethereum precompiled contract is only limited by the cosmos-sdk application layer and consensus layer.
+For information on how to interact with Polaris Ethereum's precompiled contracts, view the [Precompile Overview](../precompile-overview) section.
 

--- a/docs/web/pages/docs/contributing.mdx
+++ b/docs/web/pages/docs/contributing.mdx
@@ -1,28 +1,28 @@
 # Contributing
 
-Polaris VM welcomes contributions to its source code from anyone in the community, 
+Polaris Ethereum welcomes contributions to its source code from anyone in the community, 
 no matter how small the fix or upgrade may be. If you're interested in contributing, 
 you can start by forking the [GitHub repository], making your fix or improvement, 
 committing the changes, and then submitting a pull request for the maintainers 
 to review and merge into the main code base. However, if you plan on submitting 
 more complex changes, it's recommended to check in with the core developers on 
-the [Polaris VM Github Issues] first to ensure that your changes align with the project's 
+the [Polaris Ethereum Github Issues] first to ensure that your changes align with the project's 
 philosophy and to get some early feedback that can make the review and merge process 
 smoother for both parties.
 
-It's important that your contributions adhere to Polaris VM's coding guidelines, which 
+It's important that your contributions adhere to Polaris Ethereum's coding guidelines, which 
 include:
 - Following the official Go formatting and commentary guidelines, 
 - Basing pull requests on the `main` branch,
 - Using appropriate commit message prefixes. 
 
-All pull requests will be reviewed based on the Polaris VM's code review guidelines.
+All pull requests will be reviewed based on the Polaris Ethereum's code review guidelines.
 
-Polaris VM also encourages an early pull request approach, where contributors create pull 
+Polaris Ethereum also encourages an early pull request approach, where contributors create pull 
 requests as early as possible, even if the fix or feature is not yet completed. 
 This approach lets core developers and other volunteers know that someone is 
 working on the issue and allows for more collaborative and efficient development. 
 These early pull requests should indicate that they are "in progress".
 
 [GitHub repository]: https://github.com/berachain/polaris
-[Polaris VM Github Issues]:https://github.com/berachain/polaris/issues
+[Polaris Ethereum Github Issues]:https://github.com/berachain/polaris/issues

--- a/docs/web/pages/docs/evm-on-polaris.mdx
+++ b/docs/web/pages/docs/evm-on-polaris.mdx
@@ -19,9 +19,9 @@ how Polaris Ethereum uses these precompiled contracts.
 
 ### Custom Opcodes
 
-Custom opcodes have been added to Polaris Ethereum's EVM implementation to provide additional 
+Custom opcodes have been added to Polaris' EVM implementation to provide additional 
 functionality and support for complex smart contracts. However, some of the opcodes 
-provided by Ethereum are not compatible with Polaris Ethereum's EVM implementation, 
+provided by Ethereum are not compatible with Polaris' EVM implementation, 
 which may affect contracts that use these opcodes. The [Opcode Documentation] 
 provides information on these changes.
 

--- a/docs/web/pages/docs/evm-on-polaris.mdx
+++ b/docs/web/pages/docs/evm-on-polaris.mdx
@@ -1,13 +1,13 @@
-# EVM with Polaris VM
+# EVM with Polaris Ethereum
 
-Polaris VM offers an improved EVM experience that goes beyond the basic implementation of Ethereum.
-In addition to the reliable and consistent Ethereum functionality, Polaris VM offers developers the 
+Polaris Ethereum offers an improved EVM experience that goes beyond the basic implementation of Ethereum.
+In addition to the reliable and consistent Ethereum functionality, Polaris Ethereum offers developers the 
 creation of stateful precompiles & custom modules that developers can use to create more efficient and 
 powerful smart contracts.
 
 ## Additional Features
 
-The Polaris VM offers several additional features to enhance the EVM experience, 
+The Polaris Ethereum offers several additional features to enhance the EVM experience, 
 including stateful precompiles, and custom opcodes. In this documentation we will discuss
 these features in the context of a Cosmos-SDK based chain.
 
@@ -15,13 +15,13 @@ these features in the context of a Cosmos-SDK based chain.
 Stateful precompiles are precompiled contracts that can alter state on the 
 chain, enabling more efficient stateful operations at a lower gas cost. 
 The [Precompiles] section provides a more detailed explanation of 
-how Polaris VM uses these precompiled contracts.
+how Polaris Ethereum uses these precompiled contracts.
 
 ### Custom Opcodes
 
-Custom opcodes have been added to Polaris VM's EVM implementation to provide additional 
+Custom opcodes have been added to Polaris Ethereum's EVM implementation to provide additional 
 functionality and support for complex smart contracts. However, some of the opcodes 
-provided by Ethereum are not compatible with Polaris VM's EVM implementation, 
+provided by Ethereum are not compatible with Polaris Ethereum's EVM implementation, 
 which may affect contracts that use these opcodes. The [Opcode Documentation] 
 provides information on these changes.
 

--- a/docs/web/pages/docs/for-frontend-devs/available-tools.mdx
+++ b/docs/web/pages/docs/for-frontend-devs/available-tools.mdx
@@ -1,8 +1,8 @@
 # Available Tools
 
-There are a number of available tools for frontend dApp developers building on Polaris VM. Being an
+There are a number of available tools for frontend dApp developers building on Polaris Ethereum. Being an
 EVM compatible chain, it's tool set is interoperable with the broader EVM ecosystem.
-Here are a few of the tools available for Polaris VM:
+Here are a few of the tools available for Polaris Ethereum:
 
 ### Wagmi.sh
 [wagmi](https://wagmi.sh/) is a collection of hooks and helpers for 
@@ -16,7 +16,7 @@ When combined with [ethers.js](https://docs.ethers.org/v5/), It provides a highl
 
 ## Examples
 
-To highlight the improved user experience Polaris VM's [Stateful Precompiles](../precompile-overview)
+To highlight the improved user experience Polaris Ethereum's [Stateful Precompiles](../precompile-overview)
 provide when interacting with cosmos modules, we have created a simple example
 staking dApp that shows developers the simplicity this technology provides.
 To view how to use wagmi.sh to delegate tokens, check out the [Staking dApp example](./staking-example)

--- a/docs/web/pages/docs/for-frontend-devs/chain-config.mdx
+++ b/docs/web/pages/docs/for-frontend-devs/chain-config.mdx
@@ -1,11 +1,11 @@
 # Chain Configurations
 
-This section covers the default chain configuration for all Polaris VM 
+This section covers the default chain configuration for all Polaris Ethereum 
 environments.
 ## Local Node Configurations
 
 ### JSON RPC Configuration
-- Network Name: `Polaris VM`
+- Network Name: `Polaris Ethereum`
 - RPC URL: `http://localhost:1317/eth/rpc`
 - Chain ID: `69420`
 - Symbol(optional): `BERA`
@@ -15,7 +15,7 @@ environments.
 - RPC: `http://localhost:9090`
 - REST: `http://localhost:1317`
 - ChainID: `polaris-2061`
-- ChainName: `Polaris VM`
+- ChainName: `Polaris Ethereum`
 - BIP44: `60`
 - Bech32Config:
     - bech32PrefixAccAddr: `polaris`

--- a/docs/web/pages/docs/for-frontend-devs/staking-example.mdx
+++ b/docs/web/pages/docs/for-frontend-devs/staking-example.mdx
@@ -157,7 +157,7 @@ function App({ Component, pageProps }: AppProps) {
     <WagmiConfig client={client}>
       <RainbowKitProvider chains={chains}>
         <NextHead>
-          <title>Polaris VM Example Dapp</title>
+          <title>Polaris Ethereum Example Dapp</title>
         </NextHead>
         <ChakraProvider theme={theme}>
           {mounted && <Component {...pageProps} />}
@@ -174,7 +174,7 @@ We now have a basic themed Chakra UI setup.
 
 ## Configuring `wagmi.ts`
 
-In order to point this dapp towards a Polaris VM local node, 
+In order to point this dapp towards a Polaris Ethereum local node, 
 we need to modify `wagmi.ts`.
 
 Make `wagmi.ts` look like this:
@@ -185,14 +185,14 @@ import { jsonRpcProvider } from 'wagmi/providers/jsonRpc';
 import { connectorsForWallets } from '@rainbow-me/rainbowkit';
 import { metaMaskWallet } from '@rainbow-me/rainbowkit/wallets';
 
-// Configure chain information for local Polaris VM chain
+// Configure chain information for local Polaris Ethereum chain
 const polarisChain: Chain = {
   id: 69420,
-  name: 'Polaris VM's,
+  name: 'Polaris Ethereum's,
   network: 'polaris',
   nativeCurrency: {
     decimals: 18,
-    name: 'Polaris VM's,
+    name: 'Polaris Ethereum's,
     symbol: 'tbera',
   },
   rpcUrls: {
@@ -205,7 +205,7 @@ const polarisChain: Chain = {
   }
 };
 
-// Configure Wagmi client with Polaris VM chain
+// Configure Wagmi client with Polaris Ethereum chain
 const { provider, chains } = configureChains(
   [polarisChain],
   [
@@ -237,7 +237,7 @@ export { chains }
 
 ## Adding Utility Functions
 
-We will need to add some utility functions to our dApp. These functions will help us interact with the Polaris VM precompile.
+We will need to add some utility functions to our dApp. These functions will help us interact with the Polaris Ethereum precompile.
 
 ### Creating a `utils` Folder
 Under the `src` folder, create a new folder called `utils`. This will hold our utility functions.
@@ -958,10 +958,10 @@ function Page() {
         {/* Rainbow Kit Connect Button floating top right of the screen */}
         <ConnectButton />
       </Box>
-      <Text fontSize={'4xl'}>Polaris VM Staking Precompile Example</Text>
-      <Text fontSize={'xl'}>Ensure you have a Local <Link color={'#1da1f1'} href='TODO ADD LINK'>Polaris VM Node running.</Link></Text>
+      <Text fontSize={'4xl'}>Polaris Ethereum Staking Precompile Example</Text>
+      <Text fontSize={'xl'}>Ensure you have a Local <Link color={'#1da1f1'} href='TODO ADD LINK'>Polaris Ethereum Node running.</Link></Text>
       <Staking />
-      <Text fontSize={'xs'}>To learn more about Polaris VM please reference our <Link color={'#1da1f1'} href='TODO ADD LINK'>docs</Link></Text>
+      <Text fontSize={'xs'}>To learn more about Polaris Ethereum please reference our <Link color={'#1da1f1'} href='TODO ADD LINK'>docs</Link></Text>
     </Flex>
   )
 }
@@ -1174,7 +1174,7 @@ This will open a browser window at `http://localhost:3000/` and you should see t
 ## Conclusion
 
 Congratulations! You have now created a staking application using the EVM! You can now delegate your tBera to a validator and earn rewards!
-Prior to Polaris VM's precompiled contracts, the UX of this task would be more complicated and foreign as it involves
+Prior to Polaris Ethereum's precompiled contracts, the UX of this task would be more complicated and foreign as it involves
 many moving parts and having to use Cosmos through Metamask. Now, with the Staking precompile, we can enjoy interacting with 
 Cosmos through an EVM native experience!
 

--- a/docs/web/pages/docs/for-solidity-devs/dev-tools/available-tools.mdx
+++ b/docs/web/pages/docs/for-solidity-devs/dev-tools/available-tools.mdx
@@ -1,10 +1,10 @@
 # Developer Toolchains Overview
 
-This section provides an overview of the developer tools that are available for the Polaris VM EVM.
+This section provides an overview of the developer tools that are available for the Polaris Ethereum EVM.
 
 | Title                                                                                                                                 | Description                                                                                   |
 | :------------------------------------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------- |
-| [**Using Foundry with Polaris VM**](foundry-polaris)                                           | Using Foundry with the Polaris VM EVM |
+| [**Using Foundry with Polaris Ethereum**](foundry-polaris)                                           | Using Foundry with the Polaris Ethereum EVM |
 | [**Hardhat**](https://hardhat.org/)                                           | Smart Contract Development Framework |
 | [**Truffle**](https://trufflesuite.com/docs/truffle/)                                           | Smart Contract Development Framework |
 

--- a/docs/web/pages/docs/for-solidity-devs/dev-tools/foundry-polaris.mdx
+++ b/docs/web/pages/docs/for-solidity-devs/dev-tools/foundry-polaris.mdx
@@ -5,7 +5,7 @@ import { Callout, FileTree } from "nextra-theme-docs";
 ## Introduction
 
 This guide shows how to deploy and interact with smart contracts using foundry
-on a local Polaris VM EVM network.
+on a local Polaris Ethereum EVM network.
 
 [Foundry toolchain](https://github.com/foundry-rs/foundry) is a smart contract
 development toolchain written in Rust. It manages your dependencies, compiles
@@ -15,7 +15,7 @@ command-line.
 ## Recommended Knowledge
 
 - Basic understanding of [Solidity](https://docs.soliditylang.org) and [Cosmos](https://docs.cosmos.network/main).
-- Basic understanding of the [Polaris VM's architecture](../../architecture)
+- Basic understanding of the [Polaris Ethereum's architecture](../../architecture)
 - Basic understanding of [Liquid Staking](https://docs.stride.zone/docs/getting-started-liquid-stake)
 
 ## Requirements
@@ -24,9 +24,9 @@ command-line.
   Foundry](https://github.com/foundry-rs/foundry#installation) and run `foundryup`. This
   installation includes the `forge` and `cast` binaries used in this
   walk-through.
-- You have a running instance of Polaris VM EVM. See [Local Machine](../../running-a-node/running-locally) to run Polaris VM locally.
+- You have a running instance of Polaris Ethereum EVM. See [Local Machine](../../running-a-node/running-locally) to run Polaris Ethereum locally.
 
-## Polaris VM Liquid Staking Smart Contract Example
+## Polaris Ethereum Liquid Staking Smart Contract Example
 
 #### 1. Create A New Project With forge
 
@@ -51,11 +51,11 @@ Let's create a new project called "polaris-lsd-example" with forge.
   </FileTree.Folder>
 </FileTree>
 
-#### 2. Add Configurations For Local Polaris VM
+#### 2. Add Configurations For Local Polaris Ethereum
 
 <Callout emoji="💡">
-  Ensure that you have a local instance of Polaris VM Running. See [Local
-  Machine](../../running-a-node/running-locally) to run Polaris VM locally.
+  Ensure that you have a local instance of Polaris Ethereum Running. See [Local
+  Machine](../../running-a-node/running-locally) to run Polaris Ethereum locally.
 </Callout>
 
 You can add a profile to your foundry project by appending the following lines to the end of your foundry.toml file:
@@ -76,7 +76,7 @@ evm_version = 'berlin'
 eth_rpc_url = 'http://localhost:1317/eth/rpc'
 ```
 
-To test the configurations above, let's deploy the generated contract in the "Counter.sol" file to the Polaris VM localnet:
+To test the configurations above, let's deploy the generated contract in the "Counter.sol" file to the Polaris Ethereum localnet:
 
 ```bash
 FOUNDRY_PROFILE=polaris_local forge create Counter --private-key=xxxxxxxxxxx
@@ -558,4 +558,4 @@ FOUNDRY_PROFILE=polaris_local cast send --private-key=xxxxxxxxxxx <deployed_cont
 
 #### 9. 🎉 Congratulations! 🎉
 
-Congratulations! You have successfully created and deployed a Liquid Staking contract on Polaris VM via Foundry!
+Congratulations! You have successfully created and deployed a Liquid Staking contract on Polaris Ethereum via Foundry!

--- a/docs/web/pages/docs/for-solidity-devs/developer-overview.mdx
+++ b/docs/web/pages/docs/for-solidity-devs/developer-overview.mdx
@@ -1,43 +1,43 @@
-# Launching Your Smart Contracts on Polaris VM
+# Launching Your Smart Contracts on Polaris Ethereum
 
-The Purpose of this section is to provide information that will help you launch your smart contracts on Polaris VM. 
-You will read how to use various EVM development tools with Polaris VM along with examples. We will show you how to connect to the network, 
-how to use your existing projects on Polaris VM, as well as any additional information relating to Polaris VM's new features.
+The Purpose of this section is to provide information that will help you launch your smart contracts on Polaris Ethereum. 
+You will read how to use various EVM development tools with Polaris Ethereum along with examples. We will show you how to connect to the network, 
+how to use your existing projects on Polaris Ethereum, as well as any additional information relating to Polaris Ethereum's new features.
 
-## Polaris VM EVM 
+## Polaris Ethereum EVM 
 
-Polaris VM's EVM is designed to be as interoperable with go-ethereum as possible, which means that any tool that works with [Geth](https://geth.ethereum.org/) can also be used to interact with Polaris VM. The EVM is still responsible for executing Solidity smart contracts and managing the chain's data structures and blocks. By using CometBFT's consensus protocol and the Cosmos-SDK, Polaris VM is able to access Cosmos-SDK properties through [precompiles](../building-precompiles/intro-to-precompiles), while also remaining compatible with all Ethereum Solidity smart contracts.
+Polaris Ethereum's EVM is designed to be as interoperable with go-ethereum as possible, which means that any tool that works with [Geth](https://geth.ethereum.org/) can also be used to interact with Polaris Ethereum. The EVM is still responsible for executing Solidity smart contracts and managing the chain's data structures and blocks. By using CometBFT's consensus protocol and the Cosmos-SDK, Polaris Ethereum is able to access Cosmos-SDK properties through [precompiles](../building-precompiles/intro-to-precompiles), while also remaining compatible with all Ethereum Solidity smart contracts.
 
-It's important to note that Polaris VM's EVM is interoperable with its Cosmos-SDK Application Layer. This means that Smart Contract Developers have access to base Cosmos-SDK modules through the EVM. With this new feature, developers can access Cosmos features like on-chain governance, the IBC protocol, and various other Cosmos-SDK modules.
+It's important to note that Polaris Ethereum's EVM is interoperable with its Cosmos-SDK Application Layer. This means that Smart Contract Developers have access to base Cosmos-SDK modules through the EVM. With this new feature, developers can access Cosmos features like on-chain governance, the IBC protocol, and various other Cosmos-SDK modules.
 
 From the perspective of a Smart Contract, it will run in the same way as it would on Ethereum, but with additional contract addresses that provide access to the chain's Cosmos-SDK modules.
 
 ## Interacting With Stateful Precompiles
-Polaris VM's Stateful Precompiles can be interacted with like any 
+Polaris Ethereum's Stateful Precompiles can be interacted with like any 
 other contract deployed on the EVM in Solidity. All you need is a
 contract address and an ABI which you can find [here](../precompile-overview).
 
-For an example contract that interacts with Polaris VM's staking precompile you
+For an example contract that interacts with Polaris Ethereum's staking precompile you
 can reference our [Liquid Staking Example](https://github.com/berachain/polaris-precompile-dapp-examples).
-## Accessing Polaris VM's EVM
+## Accessing Polaris Ethereum's EVM
 
-### Running a local Polaris VM Development environment
+### Running a local Polaris Ethereum Development environment
 For a guide on how to run a local development environment, please refer to the [Local Machine](../running-a-node/running-locally) section.
 
 ### Smart Contract Development
 There are various existing tools that can be used for smart contract development.
-Below are some of the most popular tools that can be used to develop smart contracts on Polaris VM.
+Below are some of the most popular tools that can be used to develop smart contracts on Polaris Ethereum.
 
 #### Foundry
-Information on building smart contracts with Foundry on Polaris VM can be found [here](./dev-tools/foundry-polaris).
+Information on building smart contracts with Foundry on Polaris Ethereum can be found [here](./dev-tools/foundry-polaris).
 
-#### Using Metamask with Polaris VM
-Information about using Metamask with Polaris VM can be found [here](../using-metamask).
+#### Using Metamask with Polaris Ethereum
+Information about using Metamask with Polaris Ethereum can be found [here](../using-metamask).
 
-#### Using Keplr with Polaris VM
-Information about using Keplr with Polaris VM can be found [here](../using-keplr).
+#### Using Keplr with Polaris Ethereum
+Information about using Keplr with Polaris Ethereum can be found [here](../using-keplr).
 
-#### Polaris VM Block Explorer
+#### Polaris Ethereum Block Explorer
 🚧 Coming Soon 🚧
-#### Polaris VM Faucet
+#### Polaris Ethereum Faucet
 🚧 Coming Soon 🚧

--- a/docs/web/pages/docs/for-solidity-devs/developer-overview.mdx
+++ b/docs/web/pages/docs/for-solidity-devs/developer-overview.mdx
@@ -6,9 +6,9 @@ how to use your existing projects on Polaris Ethereum, as well as any additional
 
 ## Polaris Ethereum EVM 
 
-Polaris Ethereum's EVM is designed to be as interoperable with go-ethereum as possible, which means that any tool that works with [Geth](https://geth.ethereum.org/) can also be used to interact with Polaris Ethereum. The EVM is still responsible for executing Solidity smart contracts and managing the chain's data structures and blocks. By using CometBFT's consensus protocol and the Cosmos-SDK, Polaris Ethereum is able to access Cosmos-SDK properties through [precompiles](../building-precompiles/intro-to-precompiles), while also remaining compatible with all Ethereum Solidity smart contracts.
+Polaris' EVM is designed to be as interoperable with go-ethereum as possible, which means that any tool that works with [Geth](https://geth.ethereum.org/) can also be used to interact with Polaris Ethereum. The EVM is still responsible for executing Solidity smart contracts and managing the chain's data structures and blocks. By using CometBFT's consensus protocol and the Cosmos-SDK, Polaris Ethereum is able to access Cosmos-SDK properties through [precompiles](../building-precompiles/intro-to-precompiles), while also remaining compatible with all Ethereum Solidity smart contracts.
 
-It's important to note that Polaris Ethereum's EVM is interoperable with its Cosmos-SDK Application Layer. This means that Smart Contract Developers have access to base Cosmos-SDK modules through the EVM. With this new feature, developers can access Cosmos features like on-chain governance, the IBC protocol, and various other Cosmos-SDK modules.
+It's important to note that Polaris' EVM is interoperable with its Cosmos-SDK Application Layer. This means that Smart Contract Developers have access to base Cosmos-SDK modules through the EVM. With this new feature, developers can access Cosmos features like on-chain governance, the IBC protocol, and various other Cosmos-SDK modules.
 
 From the perspective of a Smart Contract, it will run in the same way as it would on Ethereum, but with additional contract addresses that provide access to the chain's Cosmos-SDK modules.
 
@@ -19,7 +19,7 @@ contract address and an ABI which you can find [here](../precompile-overview).
 
 For an example contract that interacts with Polaris Ethereum's staking precompile you
 can reference our [Liquid Staking Example](https://github.com/berachain/polaris-precompile-dapp-examples).
-## Accessing Polaris Ethereum's EVM
+## Accessing Polaris' EVM
 
 ### Running a local Polaris Ethereum Development environment
 For a guide on how to run a local development environment, please refer to the [Local Machine](../running-a-node/running-locally) section.

--- a/docs/web/pages/docs/index.mdx
+++ b/docs/web/pages/docs/index.mdx
@@ -1,16 +1,16 @@
-# Welcome to Polaris VM
+# Welcome to Polaris Ethereum
 
 Polaris introduces the new standard of intergrating EVM into your blockchain project. With improvements to speed, security, reliability,
 and an extended set of features, Polaris will be able to support the next generation of
 decentralized applications while offering a compelling alternative to existing implementations.
 
-Polaris VM is a blockchain framework built on top of the Cosmos SDK that offers a full-featured EVM with full
+Polaris Ethereum is a blockchain framework built on top of the Cosmos SDK that offers a full-featured EVM with full
 interoperability to the Cosmos ecosystem. It achieves this through the use of various [Stateful Precompiles](./docs/precompile-cosmos-overview) built
 into the chain that act as gateways to the greater Cosmos framework. This allows EVM users to perform Cosmos native operations such as voting on governance,
 delegating to validators, and even communicating with other chains through IBC. This design allows us to maintain
 the native EVM user experience without sacrifices, providing true interoperability between the Cosmos ecosystem and EVM.
 
-Apart from Polaris VM's focus on interoperability, it also offers a number of other improvements over existing
+Apart from Polaris Ethereum's focus on interoperability, it also offers a number of other improvements over existing
 EVM implementation such as :
 
 - Improved performance when executing common transactions
@@ -19,6 +19,6 @@ EVM implementation such as :
 - Reliability improvements for JSON-RPC Providers
   what we offer
 
-Overall, Polaris VM is a powerful new framework for developers and users to enjoy. Its seamless integration with other
+Overall, Polaris Ethereum is a powerful new framework for developers and users to enjoy. Its seamless integration with other
 Cosmos chains and robust EVM support make it a promising platform for building decentralized applications and unlocks
 new use cases for blockchain technology.

--- a/docs/web/pages/docs/interacting-with-node/gen-brod-sign.mdx
+++ b/docs/web/pages/docs/interacting-with-node/gen-brod-sign.mdx
@@ -2,10 +2,10 @@ import { Callout } from 'nextra-theme-docs'
 
 # Generating, Signing, and Broadcasting Transactions
 <Callout type="info" emoji="ℹ️">
-  Polaris VM CLI will work the same way as Cosmos SDK. Replace `simd` with `polard`
+  Polaris Ethereum CLI will work the same way as Cosmos SDK. Replace `simd` with `polard`
 </Callout>
 
-Polaris VM does not extend the base implementation of transaction handling in the Cosmos SDK.
-For information on handling transactions in Polaris VM you can reference [Generating, Signing and Broadcasting Transactions
+Polaris Ethereum does not extend the base implementation of transaction handling in the Cosmos SDK.
+For information on handling transactions in Polaris Ethereum you can reference [Generating, Signing and Broadcasting Transactions
 ](https://docs.cosmos.network/v0.47/run-node/txs) 
 from the Cosmos SDK documentation.

--- a/docs/web/pages/docs/interacting-with-node/querying-cli.mdx
+++ b/docs/web/pages/docs/interacting-with-node/querying-cli.mdx
@@ -3,9 +3,9 @@ import { Callout } from 'nextra-theme-docs'
 # Querying via CLI
  
 <Callout type="info" emoji="ℹ️">
-  Polaris VM CLI will work the same way as Cosmos SDK. Replace `simd` with `polard`
+  Polaris Ethereum CLI will work the same way as Cosmos SDK. Replace `simd` with `polard`
 </Callout>
 
-Polaris VM does not extend the use of CLI querying past the base implementation of the Cosmos SDK.
-For information on querying via CLI in Polaris VM you can reference [Using the CLI](https://docs.cosmos.network/main/run-node/interact-node#using-the-cli) 
+Polaris Ethereum does not extend the use of CLI querying past the base implementation of the Cosmos SDK.
+For information on querying via CLI in Polaris Ethereum you can reference [Using the CLI](https://docs.cosmos.network/main/run-node/interact-node#using-the-cli) 
 from the Cosmos SDK documentation.

--- a/docs/web/pages/docs/interacting-with-node/querying-grpc.mdx
+++ b/docs/web/pages/docs/interacting-with-node/querying-grpc.mdx
@@ -1,5 +1,5 @@
 # Querying via gRPC
 
-Polaris VM does not extend the use of gRPC past the base implementation of the Cosmos SDK.
-For information on using gRPC in Polaris VM you can reference [using gRPC](https://docs.cosmos.network/main/run-node/interact-node#using-grpc) 
+Polaris Ethereum does not extend the use of gRPC past the base implementation of the Cosmos SDK.
+For information on using gRPC in Polaris Ethereum you can reference [using gRPC](https://docs.cosmos.network/main/run-node/interact-node#using-grpc) 
 from the Cosmos SDK documentation.

--- a/docs/web/pages/docs/interacting-with-node/querying-json-rpc.mdx
+++ b/docs/web/pages/docs/interacting-with-node/querying-json-rpc.mdx
@@ -1,6 +1,6 @@
 # Querying via JSON-RPC
 
-For information about Polaris VM's JSON-RPC specification please see the [EVM JSON-RPC](../json-rpc) section.
+For information about Polaris Ethereum's JSON-RPC specification please see the [EVM JSON-RPC](../json-rpc) section.
 
 ## Querying via JSON-RPC with `ethers.js`
 

--- a/docs/web/pages/docs/interacting-with-node/querying-rest.mdx
+++ b/docs/web/pages/docs/interacting-with-node/querying-rest.mdx
@@ -1,13 +1,13 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Interacting With Polaris VM via REST
+# Interacting With Polaris Ethereum via REST
 
-Polaris VM extends the base functionality of the Cosmos-SDK for querying via REST.
+Polaris Ethereum extends the base functionality of the Cosmos-SDK for querying via REST.
 To learn more about querying the node via REST, see [here](https://docs.cosmos.network/main/run-node/interact-node#using-the-rest-endpoints).
 
 ## Swagger Open API Specification
 
-Polaris VM supports the Swagger API, which is a specification for describing RESTful APIs.
+Polaris Ethereum supports the Swagger API, which is a specification for describing RESTful APIs.
 The Swagger API is available at the following endpoints
 
 |Network   |Swagger Url   |
@@ -20,7 +20,7 @@ The Swagger API is available at the following endpoints
 Cosmos supports the Swagger API, which is a specification for describing RESTful APIs.
 To view the Cosmos-SDK Swagger API, see [here](https://v1.cosmos.network/rpc/v0.41.4)
 
-The above link will point towards the Cosmos Hub. To point towards your Polaris VM Endpoint and 
+The above link will point towards the Cosmos Hub. To point towards your Polaris Ethereum Endpoint and 
 test the base cosmos-sdk module endpoints Change `Base URL`
 to point towards your desired endpoint for testing purposes.
 

--- a/docs/web/pages/docs/introduction.mdx
+++ b/docs/web/pages/docs/introduction.mdx
@@ -1,7 +1,7 @@
-# Getting started with Polaris VM
+# Getting started with Polaris Ethereum
 
-This guide details the process of setting up Polaris VM and executing basic tasks through the command line interface. To utilize Polaris VM, the software must first be installed, which can be done in various ways depending on the preferred installation method and operating system. For instance, Polaris VM can be installed through a package manager, container, or building from source. Instructions for installing Polaris VM can be found on the relevant "Install and Build" pages.
+This guide details the process of setting up Polaris Ethereum and executing basic tasks through the command line interface. To utilize Polaris Ethereum, the software must first be installed, which can be done in various ways depending on the preferred installation method and operating system. For instance, Polaris Ethereum can be installed through a package manager, container, or building from source. Instructions for installing Polaris Ethereum can be found on the relevant "Install and Build" pages.
 
-To function as a fully fledged Ethereum Virtual Machine, Polaris VM must be integrating into a compatible host. This tutorial assumes that Polaris VM has been integrated into a Cosmos-SDK based chain with the JSON-RPC running on http://0.0.0.0:1317/eth/rpc.
+To function as a fully fledged Ethereum Virtual Machine, Polaris Ethereum must be integrating into a compatible host. This tutorial assumes that Polaris Ethereum has been integrated into a Cosmos-SDK based chain with the JSON-RPC running on http://0.0.0.0:1317/eth/rpc.
 
-The tutorial provides a step-by-step guide on the fundamentals of using Polaris VM, which includes generating accounts, joining a network, syncing the blockchain, transferring tokens between accounts, and executing smart contracts. To carry out these tasks, this tutorial uses the Cosmos SDK keychain, which is an account management tool that enables users to sign transactions.
+The tutorial provides a step-by-step guide on the fundamentals of using Polaris Ethereum, which includes generating accounts, joining a network, syncing the blockchain, transferring tokens between accounts, and executing smart contracts. To carry out these tasks, this tutorial uses the Cosmos SDK keychain, which is an account management tool that enables users to sign transactions.

--- a/docs/web/pages/docs/json-rpc-cosmos.mdx
+++ b/docs/web/pages/docs/json-rpc-cosmos.mdx
@@ -1,6 +1,6 @@
-# Polaris VM JSON-RPC
+# Polaris Ethereum JSON-RPC
 
-The Cosmos integration of the Polaris VM adds additional JSON-RPC namespaces for Cosmos related functionality.
+The Cosmos integration of the Polaris Ethereum adds additional JSON-RPC namespaces for Cosmos related functionality.
 
 ## Namespaces
 

--- a/docs/web/pages/docs/json-rpc.mdx
+++ b/docs/web/pages/docs/json-rpc.mdx
@@ -1,11 +1,11 @@
-# Polaris VM JSON-RPC
+# Polaris Ethereum JSON-RPC
 
-The Polaris VM API is accessible through JSON-RPC, a lightweight protocol for 
+The Polaris Ethereum API is accessible through JSON-RPC, a lightweight protocol for 
 transmitting data over the internet. This protocol enables developers to 
-interact with the Polaris VM blockchain and access a wide range of 
+interact with the Polaris Ethereum blockchain and access a wide range of 
 functionalities through a simple and standardized interface.
 
-Through the Polaris VM JSON-RPC endpoint, developers can access a variety of 
+Through the Polaris Ethereum JSON-RPC endpoint, developers can access a variety of 
 methods to create, modify, and interact with smart contracts, as well as 
 retrieve blockchain data and monitor blockchain events in real-time.
 

--- a/docs/web/pages/docs/opcodes.mdx
+++ b/docs/web/pages/docs/opcodes.mdx
@@ -194,7 +194,7 @@ This opcode returns the block hash of the "ethereum" block and not the block has
 ### `COINBASE`
 
 This opcode returns the address of the "fee collector", which depending on the host chain may be either the block author or the miner.
-In the Cosmos-SDK intergration of Polaris VM, it is the ModuleAddress of teh FeeCollectorAccount.
+In the Cosmos-SDK intergration of Polaris Ethereum, it is the ModuleAddress of teh FeeCollectorAccount.
 
 ### `DIFFICULTY`
 

--- a/docs/web/pages/docs/precompile-cosmos-overview.mdx
+++ b/docs/web/pages/docs/precompile-cosmos-overview.mdx
@@ -16,7 +16,7 @@ A Stateful Precompile is a precompiled contract that can alter chain state.
 ## Stateful Precompile ABI Generation
 
 In order to generate the default stateful precompile ABIs
-You must first clone the [Polaris VM repository](https://github.com/berachain/polaris).
+You must first clone the [Polaris Ethereum repository](https://github.com/berachain/polaris).
 
 You can now run the following command to generate the ABIs:
 

--- a/docs/web/pages/docs/running-a-node/running-locally-docker.mdx
+++ b/docs/web/pages/docs/running-a-node/running-locally-docker.mdx
@@ -1,4 +1,4 @@
-## Running a Polaris VM Cosmos-SDK with Docker
+## Running a Polaris Ethereum Cosmos-SDK with Docker
 
 ### From docker container artifactory
 

--- a/docs/web/pages/docs/running-a-node/running-locally.mdx
+++ b/docs/web/pages/docs/running-a-node/running-locally.mdx
@@ -1,14 +1,14 @@
-## Running a Local Polaris VM Cosmos-SDK Chain
+## Running a Local Polaris Ethereum Cosmos-SDK Chain
 
 ### From Binary
 
-The easiest way to install a Cosmos-SDK Blockchain running Polaris VM is to download a pre-built binary. You can find the latest binaries on the [releases](https://github.com/berachain/polaris/releases) page.
+The easiest way to install a Cosmos-SDK Blockchain running Polaris Ethereum is to download a pre-built binary. You can find the latest binaries on the [releases](https://github.com/berachain/polaris/releases) page.
 
 ### From Source
 
 **Step 1: Install Golang & Foundry**
 
-Go v1.20+ or higher is required for Polaris VM
+Go v1.20+ or higher is required for Polaris Ethereum
 
 1. Install [Go 1.20+ from the official site](https://go.dev/dl/) or the method of your choice. Ensure that your `GOPATH` and `GOBIN` environment variables are properly set up by using the following commands:
 
@@ -36,7 +36,7 @@ Go v1.20+ or higher is required for Polaris VM
    go version
    ```
 
-[Foundry](https://book.getfoundry.sh/getting-started/installation) is required for Polaris VM
+[Foundry](https://book.getfoundry.sh/getting-started/installation) is required for Polaris Ethereum
 
 3. Install Foundry:
 
@@ -44,7 +44,7 @@ Go v1.20+ or higher is required for Polaris VM
    curl -L https://foundry.paradigm.xyz | bash
    ```
 
-**Step 2: Get Polaris VM source code**
+**Step 2: Get Polaris Ethereum source code**
 
 Clone the `polaris` repo from the [official repo](https://github.com/berachain/polaris/) and check
 out the `main` branch for the latest stable release.

--- a/docs/web/pages/docs/running-a-node/running-on-aws.mdx
+++ b/docs/web/pages/docs/running-a-node/running-on-aws.mdx
@@ -1,4 +1,4 @@
-## Running a Polaris VM Cosmos-SDK Chain on AWS
+## Running a Polaris Ethereum Cosmos-SDK Chain on AWS
 
 The recommended way to run fault tolerant nodes that can scale to millions of requests per second would be
 with orchestration tool like [Kubernetes](https://kubernetes.io/docs/tutorials/kubernetes-basics/). Another option is to run the node on an [EC2](https://aws.amazon.com/pm/ec2/) instance.

--- a/docs/web/pages/docs/running-a-node/running-on-azure.mdx
+++ b/docs/web/pages/docs/running-a-node/running-on-azure.mdx
@@ -1,3 +1,3 @@
-## Running Polaris VM On Azure
+## Running Polaris Ethereum On Azure
 
 ### Coming soon

--- a/docs/web/pages/docs/running-a-node/running-on-gcp.mdx
+++ b/docs/web/pages/docs/running-a-node/running-on-gcp.mdx
@@ -1,3 +1,3 @@
-## Running Polaris VM On Google Cloud Platform(GCP)
+## Running Polaris Ethereum On Google Cloud Platform(GCP)
 
 ### Coming soon

--- a/docs/web/pages/docs/system-config.mdx
+++ b/docs/web/pages/docs/system-config.mdx
@@ -7,7 +7,7 @@ This guide has been tested against MacOS & Linux distributions only. To ensure a
 
 </Callout>
 
-The hardware requirements for running Polaris VM depend upon the node configuration and can change over time as upgrades to the network are implemented.
+The hardware requirements for running Polaris Ethereum depend upon the node configuration and can change over time as upgrades to the network are implemented.
 
 ## Hardware Requirements
 
@@ -18,7 +18,7 @@ This system spec has been tested by many users and validators and found to be co
 - 1TB NVMe Storage
 - 100MBPS bidirectional internet connection
 
-You can run Polaris VM on lower-spec hardware for each component, but you may find that it is not highly performant or prone to crashing.
+You can run Polaris Ethereum on lower-spec hardware for each component, but you may find that it is not highly performant or prone to crashing.
 
 ## Commonly used ports
 

--- a/docs/web/pages/docs/tracing.mdx
+++ b/docs/web/pages/docs/tracing.mdx
@@ -3,22 +3,22 @@ import { Callout } from 'nextra-theme-docs'
 # EVM Tracing
 
 Tracing allows users to examine precisely what was executed by the EVM during some specific event or in the course of a set of transactions.
-There are two different types of transactions in the Polaris VM EVM: value transfers and contract executions. A value transfer simply moves
+There are two different types of transactions in the Polaris Ethereum EVM: value transfers and contract executions. A value transfer simply moves
 the base token from one account to another. Whereas a contract interaction executes code stored at a contract address which can include altering 
 stored data and transacting multiple times with other contracts and externally-owned accounts. A contract execution transaction can 
 therefore be a complicated web of interactions that can be difficult to unpick. The transaction receipt contains a status code that 
 shows whether the transaction succeeded or failed, but more detailed information is not readily available, meaning it is very difficult 
 to know what a contract execution actually did, what data was modified and which addresses were touched. This is the problem that EVM 
-tracing solves. Polaris VM's interface traces transactions by re-running them locally and collecting data about precisely what was executed by the EVM.
+tracing solves. Polaris Ethereum's interface traces transactions by re-running them locally and collecting data about precisely what was executed by the EVM.
 
 ## State Availability
 
-In its simplest form, tracing a transaction entails requesting the Polaris VM node to reexecute the desired transaction with 
-varying degrees of data collection and have it return an aggregated summary. In order for a Polaris VM node to reexecute a transaction, 
+In its simplest form, tracing a transaction entails requesting the Polaris Ethereum node to reexecute the desired transaction with 
+varying degrees of data collection and have it return an aggregated summary. In order for a Polaris Ethereum node to reexecute a transaction, 
 all historical state accessed by the transaction must be available. 
 
-By Default, all Polaris VM nodes are archval nodes.
-It is possible to run a Polaris VM light client but for EVM tracing, a full node is required.
+By Default, all Polaris Ethereum nodes are archval nodes.
+It is possible to run a Polaris Ethereum light client but for EVM tracing, a full node is required.
 
 <Callout emoji="💡">
 An archive node retains all historical data back to genesis. It can therefore trace arbitrary transactions at any point in the history of the chain. Tracing a single transaction requires reexecuting all preceding transactions in the same block.
@@ -31,18 +31,18 @@ An archive node retains all historical data back to genesis. It can therefore tr
 
 ### Basic Traces
 
-Polaris VM has the ability to produce basic transaction traces in the form of raw EVM opcode traces. These traces contain detailed information about every EVM instruction executed during a transaction, 
+Polaris Ethereum has the ability to produce basic transaction traces in the form of raw EVM opcode traces. These traces contain detailed information about every EVM instruction executed during a transaction, 
 such as the opcode name, cost, program counter, remaining gas, error (if any), and execution depth. Additionally, the structured logs can 
 include the content of the execution stack, memory, and contract storage, if desired. Example [Coming Soon]().
 
 ### Built-in Tracers
 
-The tracing API of Polaris VM allows the user to specify a tracer parameter, 
+The tracing API of Polaris Ethereum allows the user to specify a tracer parameter, 
 which determines how the data returned from the API call should be processed. 
 If the tracer parameter is not provided, the default tracer (the struct logger) 
 is used. While the default tracer produces raw opcode traces, they can be 
 cumbersome and difficult to read for many use cases, and can also be quite 
-resource-intensive to process. To address these issues, Polaris VM includes 
+resource-intensive to process. To address these issues, Polaris Ethereum includes 
 a set of non-default built-in tracers that can be specified in the API 
 call to return different types of data. These built-in tracers are Go functions 
 that perform specific preprocessing on the trace data 
@@ -50,7 +50,7 @@ before returning it.  Example [Coming Soon]().
 
 ### Custom Tracers
 
-Besides the built-in tracers, Polaris VM also allows users to create custom tracers 
+Besides the built-in tracers, Polaris Ethereum also allows users to create custom tracers 
 that can process and return data from events in the EVM in a more convenient format. 
 These custom tracers can be written in either Javascript or Go. Javascript tracers are 
 suitable for quick prototyping, experimentation, and less resource-intensive applications. 

--- a/docs/web/pages/docs/using-metamask.mdx
+++ b/docs/web/pages/docs/using-metamask.mdx
@@ -1,14 +1,14 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Using Metamask With Polaris VM
+# Using Metamask With Polaris Ethereum
 
 In this section, we will guide you through the process of 
-downloading Metamask and connecting it to a local Polaris VM node. 
+downloading Metamask and connecting it to a local Polaris Ethereum node. 
 Before proceeding, please ensure that you have a local node up and running. 
 If you need help with this, you can refer to the [Local Machine](./running-a-node/running-locally) section for instructions.
 
 To begin, you will need to download and install the Metamask browser extension. 
-Once installed, you can then connect your Injected Metamask to your local Polaris VM 
+Once installed, you can then connect your Injected Metamask to your local Polaris Ethereum 
 node by following the steps provided in this section.
 
  
@@ -19,7 +19,7 @@ node by following the steps provided in this section.
 ## Downloading And Installing Metamask
 You can download and install the Metamask browser extension [here](https://metamask.io/download/).
 
-## Adding Polaris VM Local Network
+## Adding Polaris Ethereum Local Network
 Click to MetaMask icon on the browser and select the network drop-down menu. Here we should connect to C-Chain. Click to "Custom RPC".
 
 ![](/metamask-add-network.png)
@@ -28,7 +28,7 @@ Remove the existing `Localhost 8545` default network.
 
 Now, we need to input the following values/
 
-- Network Name: `Polaris VM`
+- Network Name: `Polaris Ethereum`
 - New RPC URL: `http://localhost:1317/eth/rpc`
 - Chain ID: `69420`
 - Symbol(optional): `BERA`
@@ -36,7 +36,7 @@ Now, we need to input the following values/
 
 Click `Save`
 
-The Polaris VM local environment is now available on your Metamask browser wallet.
+The Polaris Ethereum local environment is now available on your Metamask browser wallet.
 
 ## Importing Default Private Keys
 

--- a/docs/web/pages/index.mdx
+++ b/docs/web/pages/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Polaris VM
+title: Polaris Ethereum
 ---
 
 import createGlobe from "cobe";
@@ -183,7 +183,7 @@ import Link from "next/link";
       fontSize: 14,
     }}
   >
-    Polaris VM is currently licensed under BUSL-1.1 →
+    Polaris Ethereum is currently licensed under BUSL-1.1 →
   </Link>
 </div>
 

--- a/docs/web/theme.config.jsx
+++ b/docs/web/theme.config.jsx
@@ -11,14 +11,14 @@ export default {
     banner: {
         key: '2.0-release',
         text: <a href="https://medium.com/berachain-foundation/introducing-polaris-vm-2a0b77d777f8" target="_blank">
-          🎉 Introducing Polaris VM! 
+          🎉 Introducing Polaris Ethereum! 
         </a>,
     },
     useNextSeoProps() {
         const { route } = useRouter()
         if (route !== '/') {
             return {
-                titleTemplate: '%s – Polaris VM Docs'
+                titleTemplate: '%s – Polaris Ethereum Docs'
             }
         }
     },
@@ -33,23 +33,23 @@ export default {
                 <meta httpEquiv="Content-Language" content="en" />
                 <meta
                     name="description"
-                    content="Polaris VM brings EVM to Cosmos in a new way"
+                    content="Polaris Ethereum brings EVM to Cosmos in a new way"
                 />
                 <meta
                     name="og:description"
-                    content="Polaris VM brings EVM to Cosmos in a new way"
+                    content="Polaris Ethereum brings EVM to Cosmos in a new way"
                 />
                 <meta name="twitter:card" content="summary_large_image" />
                 <meta name="twitter:image" content="/header.png" />
                 <meta name="twitter:site:domain" content="https://polaris.berachain.dev/" />
-                <meta property="twitter:description" content="Polaris VM brings EVM to Cosmos in a new way"/>
+                <meta property="twitter:description" content="Polaris Ethereum brings EVM to Cosmos in a new way"/>
                 <meta name="twitter:url" content="https://polaris.berachain.dev/" />
                 <meta
                     name="og:title"
-                    content={title ? title + ' – Polaris VM' : 'Polaris VM'}
+                    content={title ? title + ' – Polaris Ethereum' : 'Polaris Ethereum'}
                 />
                 <meta name="og:image" content={socialCard} />
-                <meta name="apple-mobile-web-app-title" content="Polaris VM" />
+                <meta name="apple-mobile-web-app-title" content="Polaris Ethereum" />
                 <link rel="icon" href="/milky-way.png" type="image/png" />
                 <link rel="icon" href="/milky-way.ico"/>
                 <link

--- a/host/README.md
+++ b/host/README.md
@@ -2,5 +2,5 @@
 
 Currently Polaris supports the following host chains:
 
-* `cosmos` - Intergrates Polaris VM as a Cosmos-SDK Chain
-* `playground` - Integrates Polaris VM into a simple example blockchain. 
+* `cosmos` - Intergrates Polaris Ethereum as a Cosmos-SDK Chain
+* `playground` - Integrates Polaris Ethereum into a simple example blockchain. 

--- a/host/cosmos/x/README.md
+++ b/host/cosmos/x/README.md
@@ -2,4 +2,4 @@
 
 Polaris implements the following custom modules:
 
-* `evm` - Intergrates the Polaris VM as a Cosmos-SDK module
+* `evm` - Intergrates the Polaris Ethereum as a Cosmos-SDK module

--- a/host/playground/README.md
+++ b/host/playground/README.md
@@ -1,7 +1,7 @@
 ![](../../docs/web/public/playground.png)
 &nbsp;
 
-> The Polaris Playground is a simple, in-memory local development environment for Polaris VM. It is intended to be used for development and testing of experimental Polaris VM features, by simulating an extremely simple blockchain. It is not intended for production use.
+> The Polaris Playground is a simple, in-memory local development environment for Polaris Ethereum. It is intended to be used for development and testing of experimental Polaris Ethereum features, by simulating an extremely simple blockchain. It is not intended for production use.
 
 # Running the Playground
 


### PR DESCRIPTION
Change branding to Polaris Ethereum (Polaris Eth, peth, etc.) as its more accurate than Polaris VM. We provide an alternative and to Geth as (Peth) and not an alternative to the Ethereum VM itself