### PR TITLE
fix(eth): Correctly set tx hash on the eth block header 

### DIFF
--- a/contracts/src/cosmos/precompile/examples/LiquidStaking.sol
+++ b/contracts/src/cosmos/precompile/examples/LiquidStaking.sol
@@ -38,8 +38,7 @@ import {ERC20} from "../../../../lib/ERC20.sol";
  */
 contract LiquidStaking is ERC20 {
     // State
-    IStakingModule public immutable staking =
-        IStakingModule(0xd9A998CaC66092748FfEc7cFBD155Aae1737C2fF);
+    IStakingModule public immutable staking = IStakingModule(0xd9A998CaC66092748FfEc7cFBD155Aae1737C2fF);
     // address public validatorAddress;
 
     event Success(bool indexed success);
@@ -55,10 +54,7 @@ contract LiquidStaking is ERC20 {
      * @param _name The name of the token.
      * @param _symbol The symbol of the token.
      */
-    constructor(
-        string memory _name,
-        string memory _symbol
-    ) ERC20(_name, _symbol, 18) {}
+    constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol, 18) {}
 
     // /**
     //  * @dev Returns the total amount of assets delegated to the validator.

--- a/eth/core/chain_writer.go
+++ b/eth/core/chain_writer.go
@@ -83,7 +83,7 @@ func (bc *blockchain) ProcessTransaction(ctx context.Context, tx *types.Transact
 }
 
 // Finalize finalizes the current block.
-func (bc *blockchain) Finalize(ctx context.Context) error {
+func (bc *blockchain) Finalize(ctx context. ) error {
 	block, receipts, logs, err := bc.processor.Finalize(ctx)
 	if err != nil {
 		return err

--- a/eth/core/chain_writer.go
+++ b/eth/core/chain_writer.go
@@ -83,7 +83,7 @@ func (bc *blockchain) ProcessTransaction(ctx context.Context, tx *types.Transact
 }
 
 // Finalize finalizes the current block.
-func (bc *blockchain) Finalize(ctx context. ) error {
+func (bc *blockchain) Finalize(ctx context.Context) error {
 	block, receipts, logs, err := bc.processor.Finalize(ctx)
 	if err != nil {
 		return err
@@ -128,7 +128,7 @@ func (bc *blockchain) Finalize(ctx context. ) error {
 }
 
 // Commit commits the current block to the blockchain and emits chain events.
-func (bc *blockchain) Commit(ctx context.Context) {
+func (bc *blockchain) Commit(_ context.Context) {
 	if block := bc.currentBlock.Load(); block != nil {
 		// Cache finalized block.
 		blockHash, blockNum := block.Hash(), block.NumberU64()

--- a/eth/core/processor.go
+++ b/eth/core/processor.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/trie"
+
 	"pkg.berachain.dev/polaris/eth/core/precompile"
 	"pkg.berachain.dev/polaris/eth/core/types"
 	"pkg.berachain.dev/polaris/eth/core/vm"

--- a/eth/core/processor.go
+++ b/eth/core/processor.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ethereum/go-ethereum/trie"
 	"pkg.berachain.dev/polaris/eth/core/precompile"
 	"pkg.berachain.dev/polaris/eth/core/types"
 	"pkg.berachain.dev/polaris/eth/core/vm"
@@ -217,6 +218,13 @@ func (sp *StateProcessor) Finalize(
 
 	// Now that we are done processing the block, we update the header with the consumed gas.
 	sp.header.GasUsed = sp.gp.BlockGasConsumed()
+
+	// set the tx hash on the header
+	if len(sp.txs) == 0 {
+		sp.header.TxHash = types.EmptyTxsHash
+	} else {
+		sp.header.TxHash = types.DeriveSha((sp.txs), trie.NewStackTrie(nil))
+	}
 
 	// We iterate over all of the receipts/transactions in the block and update the receipt to
 	// have the correct values. We must do this AFTER all the transactions have been processed

--- a/eth/core/processor.go
+++ b/eth/core/processor.go
@@ -219,7 +219,7 @@ func (sp *StateProcessor) Finalize(
 	// Now that we are done processing the block, we update the header with the consumed gas.
 	sp.header.GasUsed = sp.gp.BlockGasConsumed()
 
-	// set the tx hash on the header
+	// Set the tx hash on the header so that the block hash is correct.
 	if len(sp.txs) == 0 {
 		sp.header.TxHash = types.EmptyTxsHash
 	} else {

--- a/eth/core/types/imported.go
+++ b/eth/core/types/imported.go
@@ -56,6 +56,7 @@ var (
 	AccessListTxType       = types.AccessListTxType
 	DeriveSha              = types.DeriveSha
 	EmptyRootHash          = types.EmptyRootHash
+	EmptyTxsHash           = types.EmptyTxsHash
 	EmptyUncleHash         = types.EmptyUncleHash
 	SignTx                 = types.SignTx
 	NewTx                  = types.NewTx


### PR DESCRIPTION
We were not setting the `TxHash` field on the header, which caused inconsistent hashes of the block header.