### PR TITLE
fix(core): Active Precompiles pulled from host chain plugin

### DIFF
--- a/cosmos/go.mod
+++ b/cosmos/go.mod
@@ -8,7 +8,7 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/cosmos/cosmos-sdk v0.46.0-beta2.0.20230423204932-f0018246f107
 
 	// Required for stateful precompiles and supporting the Ethereum JSON-RPC API.
-	github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6
+	github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
 

--- a/cosmos/go.sum
+++ b/cosmos/go.sum
@@ -282,8 +282,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6 h1:RwXAVUBO1Q+ocDstB59UjlpWXrhcVuxMQsW5SBXe6ZI=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e h1:k87SsTlF8GOCIF6rg8y37qjAbXY18vMBAOdqWsXMBEs=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/cosmos/x/evm/plugins/precompile/plugin.go
+++ b/cosmos/x/evm/plugins/precompile/plugin.go
@@ -85,7 +85,7 @@ func (p *plugin) GetPrecompiles(_ *params.Rules) []ethprecompile.Registrable {
 // GetActive implements core.PrecompilePlugin.
 func (p *plugin) GetActive(rules *params.Rules) []common.Address {
 	defaults := ethprecompile.GetDefaultPrecompiles(rules)
-	active := make([]common.Address, 0, len(p.precompiles)+len(defaults))
+	active := make([]common.Address, len(p.precompiles)+len(defaults))
 	for i, pc := range p.precompiles {
 		active[i] = pc.RegistryKey()
 	}

--- a/cosmos/x/evm/plugins/precompile/plugin.go
+++ b/cosmos/x/evm/plugins/precompile/plugin.go
@@ -32,7 +32,7 @@ import (
 	"pkg.berachain.dev/polaris/cosmos/x/evm/plugins/state"
 	"pkg.berachain.dev/polaris/eth/common"
 	"pkg.berachain.dev/polaris/eth/core"
-	"pkg.berachain.dev/polaris/eth/core/precompile"
+	ethprecompile "pkg.berachain.dev/polaris/eth/core/precompile"
 	"pkg.berachain.dev/polaris/eth/core/vm"
 	"pkg.berachain.dev/polaris/eth/params"
 	"pkg.berachain.dev/polaris/lib/registry"
@@ -55,7 +55,7 @@ type Plugin interface {
 type plugin struct {
 	libtypes.Registry[common.Address, vm.PrecompileContainer]
 	// precompiles is all supported precompile contracts.
-	precompiles []precompile.Registrable
+	precompiles []ethprecompile.Registrable
 	// kvGasConfig is the gas config for the KV store.
 	kvGasConfig storetypes.GasConfig
 	// transientKVGasConfig is the gas config for the transient KV store.
@@ -64,8 +64,8 @@ type plugin struct {
 	sp StatePlugin
 }
 
-// NewPlugin creates and returns a `plugin` with the default kv gas configs.
-func NewPlugin(precompiles []precompile.Registrable, sp StatePlugin) Plugin {
+// NewPlugin creates and returns a plugin with the default KV store gas configs.
+func NewPlugin(precompiles []ethprecompile.Registrable, sp StatePlugin) Plugin {
 	return &plugin{
 		Registry:    registry.NewMap[common.Address, vm.PrecompileContainer](),
 		precompiles: precompiles,
@@ -77,23 +77,39 @@ func NewPlugin(precompiles []precompile.Registrable, sp StatePlugin) Plugin {
 	}
 }
 
-// GetPrecompiles implements `core.PrecompilePlugin`.
-func (p *plugin) GetPrecompiles(_ *params.Rules) []precompile.Registrable {
+// GetPrecompiles implements core.PrecompilePlugin.
+func (p *plugin) GetPrecompiles(_ *params.Rules) []ethprecompile.Registrable {
 	return p.precompiles
 }
 
+// GetActive implements core.PrecompilePlugin.
+func (p *plugin) GetActive(rules *params.Rules) []common.Address {
+	var active []common.Address
+	for _, pc := range p.precompiles {
+		active = append(active, pc.RegistryKey())
+	}
+	for _, pc := range ethprecompile.GetDefaultPrecompiles(rules) {
+		active = append(active, pc.RegistryKey())
+	}
+	return active
+}
+
+// KVGasConfig implements Plugin.
 func (p *plugin) KVGasConfig() storetypes.GasConfig {
 	return p.kvGasConfig
 }
 
+// SetKVGasConfig implements Plugin.
 func (p *plugin) SetKVGasConfig(kvGasConfig storetypes.GasConfig) {
 	p.kvGasConfig = kvGasConfig
 }
 
+// TransientKVGasConfig implements Plugin.
 func (p *plugin) TransientKVGasConfig() storetypes.GasConfig {
 	return p.transientKVGasConfig
 }
 
+// SetTransientKVGasConfig implements Plugin.
 func (p *plugin) SetTransientKVGasConfig(transientKVGasConfig storetypes.GasConfig) {
 	p.transientKVGasConfig = transientKVGasConfig
 }
@@ -102,9 +118,9 @@ func (p *plugin) SetTransientKVGasConfig(transientKVGasConfig storetypes.GasConf
 // a Cosmos SDK `GasMeter`. This function returns an error if the precompile execution returns an
 // error or insufficient gas is provided.
 //
-// Run implements `core.PrecompilePlugin`.
+// Run implements core.PrecompilePlugin.
 func (p *plugin) Run(
-	evm precompile.EVM, pc vm.PrecompileContainer, input []byte,
+	evm ethprecompile.EVM, pc vm.PrecompileContainer, input []byte,
 	caller common.Address, value *big.Int, suppliedGas uint64, readonly bool,
 ) ([]byte, uint64, error) {
 	// use a precompile-specific gas meter for dynamic consumption
@@ -146,7 +162,7 @@ func (p *plugin) Run(
 
 // EnableReentrancy sets the state so that execution can enter the EVM again.
 //
-// EnableReentrancy implements `core.PrecompilePlugin`.
+// EnableReentrancy implements core.PrecompilePlugin.
 func (p *plugin) EnableReentrancy(_ context.Context) {
 	// We remove the KVStore gas metering from the context prior to entering the EVM state
 	// transition. This is because the EVM is not aware of the Cosmos SDK's gas metering and is
@@ -158,7 +174,7 @@ func (p *plugin) EnableReentrancy(_ context.Context) {
 
 // DisableReentrancy sets the state so that execution cannot enter the EVM again.
 //
-// DisableReentrancy implements `core.PrecompilePlugin`.
+// DisableReentrancy implements core.PrecompilePlugin.
 func (p *plugin) DisableReentrancy(ctx context.Context) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	// restore ctx gas configs for continuing precompile execution

--- a/cosmos/x/evm/plugins/precompile/plugin.go
+++ b/cosmos/x/evm/plugins/precompile/plugin.go
@@ -84,12 +84,13 @@ func (p *plugin) GetPrecompiles(_ *params.Rules) []ethprecompile.Registrable {
 
 // GetActive implements core.PrecompilePlugin.
 func (p *plugin) GetActive(rules *params.Rules) []common.Address {
-	var active []common.Address
-	for _, pc := range p.precompiles {
-		active = append(active, pc.RegistryKey())
+	defaults := ethprecompile.GetDefaultPrecompiles(rules)
+	active := make([]common.Address, 0, len(p.precompiles)+len(defaults))
+	for i, pc := range p.precompiles {
+		active[i] = pc.RegistryKey()
 	}
-	for _, pc := range ethprecompile.GetDefaultPrecompiles(rules) {
-		active = append(active, pc.RegistryKey())
+	for i, pc := range defaults {
+		active[i+len(p.precompiles)] = pc.RegistryKey()
 	}
 	return active
 }

--- a/eth/core/precompile/default_plugin.go
+++ b/eth/core/precompile/default_plugin.go
@@ -45,14 +45,24 @@ func NewDefaultPlugin() Plugin {
 	}
 }
 
-// GetPrecompiles implements `core.PrecompilePlugin`.
+// GetPrecompiles implements core.PrecompilePlugin.
 func (dp *defaultPlugin) GetPrecompiles(rules *params.Rules) []Registrable {
 	return GetDefaultPrecompiles(rules)
 }
 
+// GetActive implements core.PrecompilePlugin.
+func (dp *defaultPlugin) GetActive(rules *params.Rules) []common.Address {
+	pc := dp.GetPrecompiles(rules)
+	active := make([]common.Address, 0, len(pc))
+	for i, p := range pc {
+		active[i] = p.RegistryKey()
+	}
+	return active
+}
+
 // Run supports executing stateless precompiles with the background context.
 //
-// Run implements `core.PrecompilePlugin`.
+// Run implements core.PrecompilePlugin.
 func (dp *defaultPlugin) Run(
 	evm EVM, pc vm.PrecompileContainer, input []byte,
 	caller common.Address, value *big.Int, suppliedGas uint64, readonly bool,
@@ -68,12 +78,13 @@ func (dp *defaultPlugin) Run(
 	return output, suppliedGas, err
 }
 
-// EnableReentrancy implements `core.PrecompilePlugin`.
+// EnableReentrancy implements core.PrecompilePlugin.
 func (dp *defaultPlugin) EnableReentrancy(context.Context) {}
 
-// DisableReentrancy implements `core.PrecompilePlugin`.
+// DisableReentrancy implements core.PrecompilePlugin.
 func (dp *defaultPlugin) DisableReentrancy(context.Context) {}
 
+// GetDefaultPrecompiles returns the default set of precompiles for the given rules.
 func GetDefaultPrecompiles(rules *params.Rules) []Registrable {
 	// Depending on the hard fork rules, we need to register a different set of precompiles.
 	var addrToPrecompiles map[common.Address]vm.PrecompileContainer

--- a/eth/go.mod
+++ b/eth/go.mod
@@ -3,7 +3,7 @@ module pkg.berachain.dev/polaris/eth
 go 1.20
 
 // Required for stateful precompiles and supporting the Ethereum JSON-RPC API.
-replace github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6
+replace github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/eth/go.sum
+++ b/eth/go.sum
@@ -18,8 +18,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6 h1:RwXAVUBO1Q+ocDstB59UjlpWXrhcVuxMQsW5SBXe6ZI=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e h1:k87SsTlF8GOCIF6rg8y37qjAbXY18vMBAOdqWsXMBEs=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=

--- a/go.work.sum
+++ b/go.work.sum
@@ -181,8 +181,8 @@ github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.36.30/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6 h1:RwXAVUBO1Q+ocDstB59UjlpWXrhcVuxMQsW5SBXe6ZI=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e h1:k87SsTlF8GOCIF6rg8y37qjAbXY18vMBAOdqWsXMBEs=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/playground/go.mod
+++ b/playground/go.mod
@@ -3,7 +3,7 @@ module pkg.berachain.dev/polaris/playground
 go 1.20
 
 // Required for stateful precompiles and supporting the Ethereum JSON-RPC API.
-replace github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6
+replace github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e
 
 require (
 	github.com/rs/zerolog v1.29.1

--- a/playground/go.sum
+++ b/playground/go.sum
@@ -16,8 +16,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6 h1:RwXAVUBO1Q+ocDstB59UjlpWXrhcVuxMQsW5SBXe6ZI=
-github.com/berachain/polaris-geth v0.0.0-20230425211649-bf6ba6cc2df6/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e h1:k87SsTlF8GOCIF6rg8y37qjAbXY18vMBAOdqWsXMBEs=
+github.com/berachain/polaris-geth v0.0.0-20230508170330-367aa064bf2e/go.mod h1:it7x0DWnTDMfVFdXcU6Ti4KEFQynLHVRarcSlPr0HBo=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2 h1:5n0X6hX0Zk+6omWcihdYvdAlGf2DfasC0GMf7DClJ3U=
 github.com/btcsuite/btcd/btcec/v2 v2.3.2/go.mod h1:zYzJ8etWJQIv1Ogk7OzpWjowwOdXY1W/17j2MW85J04=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=


### PR DESCRIPTION
- Previously only the default geth precompiles were considered as Active Precompiles. Now it is pulling from the host chain's precompile plugin
- Also update to cleanup geth dep