### PR TITLE
Update polaris.toml to enable web3 methods used by hardhat

### DIFF
--- a/cosmos/runtime/localnode/config/polaris.toml
+++ b/cosmos/runtime/localnode/config/polaris.toml
@@ -3,14 +3,14 @@ HTTPHost = "0.0.0.0"
 HTTPPort = 8545
 HTTPCors = ["*"]
 HTTPVirtualHosts = ["*"]
-HTTPModules = ["eth", "net"]
+HTTPModules = ["eth", "net", "web3"]
 AuthAddr = "0.0.0.0"
 AuthPort = 8546
 AuthVirtualHosts = ["0.0.0.0"]
 WSHost = "0.0.0.0"
 WSPort = 8546
 WSOrigins = ["*"]
-WSModules = ["eth", "net"]
+WSModules = ["eth", "net", "web3"]
 GraphQLCors = ["*"]
 GraphQLVirtualHosts = ["0.0.0.0"]
 


### PR DESCRIPTION
Hardhat uses methods under the `web3` namespace such as `web3_clientVersion` and `web3_sha3`, but does not methods are not available by default when running `mage start`. Updating the `polaris.toml` file for the local node config makes these methods available and thus avoids some issues when using hardhat against a Polaris instance