### PR TITLE
fix(helper): Sort coins in ExtractCoinsFromInput + add tests 

### DIFF
--- a/cosmos/lib/conversions.go
+++ b/cosmos/lib/conversions.go
@@ -65,6 +65,9 @@ func ExtractCoinsFromInput(coins any) (sdk.Coins, error) {
 	for _, evmCoin := range amounts {
 		sdkCoins = append(sdkCoins, sdk.NewCoin(evmCoin.Denom, sdk.NewIntFromBigInt(evmCoin.Amount)))
 	}
+	// sort the coins by denom, as Cosmos expects.
+	sdkCoins = sdkCoins.Sort()
+
 	return sdkCoins, nil
 }
 

--- a/cosmos/precompile/bank/bank_test.go
+++ b/cosmos/precompile/bank/bank_test.go
@@ -132,6 +132,7 @@ var _ = Describe("Bank Precompile Test", func() {
 		)
 
 		denom := "abera"
+		denom2 := "atoken"
 
 		When("GetBalance", func() {
 			It("should fail if input address is not a common.Address", func() {
@@ -666,28 +667,37 @@ var _ = Describe("Bank Precompile Test", func() {
 			})
 
 			It("should succeed", func() {
-				balanceAmount, ok := new(big.Int).SetString("22000000000000000000", 10)
+				balanceAmount, ok := new(big.Int).SetString("220000000000000000", 10)
 				Expect(ok).To(BeTrue())
 
 				accs := simtestutil.CreateRandomAccounts(2)
 				fromAcc, toAcc := accs[0], accs[1]
 
-				coins := sdk.NewCoins(
+				sortedSdkCoins := sdk.NewCoins(
 					sdk.NewCoin(
 						denom,
 						sdk.NewIntFromBigInt(balanceAmount),
 					),
+					sdk.NewCoin(
+						denom2,
+						sdk.NewIntFromBigInt(balanceAmount),
+					),
 				)
+
+				unsortedSdkCoins := sdk.NewCoins()
+				unsortedSdkCoins = append(unsortedSdkCoins, sdk.NewCoin(denom2, sdk.NewIntFromBigInt(balanceAmount)))
+				unsortedSdkCoins = append(unsortedSdkCoins, sdk.NewCoin(denom, sdk.NewIntFromBigInt(balanceAmount)))
 
 				err := FundAccount(
 					ctx,
 					bk,
 					fromAcc,
-					coins,
+					sortedSdkCoins,
 				)
 				Expect(err).ToNot(HaveOccurred())
 
 				bk.SetSendEnabled(ctx, denom, true)
+				bk.SetSendEnabled(ctx, denom2, true)
 
 				_, err = contract.Send(
 					ctx,
@@ -697,14 +707,14 @@ var _ = Describe("Bank Precompile Test", func() {
 					true,
 					cosmlib.AccAddressToEthAddress(fromAcc),
 					cosmlib.AccAddressToEthAddress(toAcc),
-					sdkCoinsToEvmCoins(coins),
+					sdkCoinsToEvmCoins(unsortedSdkCoins),
 				)
 				Expect(err).ToNot(HaveOccurred())
 
-				balance, err := bk.Balance(ctx, banktypes.NewQueryBalanceRequest(toAcc, denom))
+				balances, err := bk.AllBalances(ctx, banktypes.NewQueryAllBalancesRequest(toAcc, nil, false))
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(*balance.Balance).To(Equal(coins[0]))
+				Expect(balances.Balances).To(Equal(sortedSdkCoins))
 			})
 		})
 	})

--- a/cosmos/testing/integration/precompile/bank/bank_test.go
+++ b/cosmos/testing/integration/precompile/bank/bank_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Bank", func() {
 	denom3 := "stake"
 
 	It("should call functions on the precompile directly", func() {
-		numberOfDenoms := 7
+		numberOfDenoms := 8
 		coinsToBeSent := []bindings.CosmosCoin{
 			{
 				Denom:  denom,
@@ -128,9 +128,9 @@ var _ = Describe("Bank", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(spendableBalances).To(Equal(expectedAllBalance))
 
-		atokenSupply, err := bankPrecompile.GetSupply(nil, denom2)
+		atokenSupply, err := bankPrecompile.GetSupply(nil, "asupply")
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(atokenSupply).To(Equal(big.NewInt(100)))
+		Expect(atokenSupply).To(Equal(big.NewInt(1000000000000000000)))
 
 		totalSupply, err := bankPrecompile.GetAllSupply(nil)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/cosmos/testing/network/network.go
+++ b/cosmos/testing/network/network.go
@@ -164,6 +164,10 @@ func BuildGenesisState(keysMap map[string]*ethsecp256k1.PrivKey) map[string]json
 			Enabled: true,
 		},
 		{
+			Denom:   "atoken",
+			Enabled: true,
+		},
+		{
 			Denom:   "stake",
 			Enabled: true,
 		},
@@ -250,6 +254,7 @@ func getCoinsForAccount(name string) sdk.Coins {
 			sdk.NewCoin("bAKT", sdk.NewInt(12345)), //nolint:gomnd // its okay.
 			sdk.NewCoin("stake", sdk.NewInt(examoney)),
 			sdk.NewCoin("bOSMO", sdk.NewInt(12345*2)), //nolint:gomnd // its okay.
+			sdk.NewCoin("atoken", sdk.NewInt(examoney)),
 		)
 	case "bob":
 		return sdk.NewCoins(

--- a/cosmos/testing/network/network.go
+++ b/cosmos/testing/network/network.go
@@ -255,6 +255,8 @@ func getCoinsForAccount(name string) sdk.Coins {
 			sdk.NewCoin("stake", sdk.NewInt(examoney)),
 			sdk.NewCoin("bOSMO", sdk.NewInt(12345*2)), //nolint:gomnd // its okay.
 			sdk.NewCoin("atoken", sdk.NewInt(examoney)),
+			// do not change the supply of this coin
+			sdk.NewCoin("asupply", sdk.NewInt(examoney)),
 		)
 	case "bob":
 		return sdk.NewCoins(


### PR DESCRIPTION
Sort coins in ExtractCoinsFromInput + add tests 
`func ExtractCoinsFromInput` in conversions.go previous use sdkCoins.Add() which has built-in sanitize coin and sort function, however, it would remove coins with amount=0, which we need for dex init pool. 
Then we changed it to append(), so a manual sort is needed. 