### PR TITLE
fix(txpool): Return correct pending nonce for both cosmos and eth txs

### DIFF
--- a/cosmos/x/evm/plugins/txpool/mempool/mempool_reader.go
+++ b/cosmos/x/evm/plugins/txpool/mempool/mempool_reader.go
@@ -200,7 +200,7 @@ func (etp *EthTxPool) Content() (
 func getTxSenderNonce(tx sdk.Tx) (common.Address, uint64) {
 	sigs, err := tx.(signing.SigVerifiableTx).GetSignaturesV2()
 	if err != nil || len(sigs) == 0 {
-		panic("yay")
+		return common.Address{}, 0
 	}
 	return cosmlib.AccAddressToEthAddress(sdk.AccAddress(sigs[0].PubKey.Address())), sigs[0].Sequence
 }

--- a/cosmos/x/evm/plugins/txpool/mempool/mempool_reader.go
+++ b/cosmos/x/evm/plugins/txpool/mempool/mempool_reader.go
@@ -23,6 +23,10 @@ package mempool
 import (
 	"context"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+
+	cosmlib "pkg.berachain.dev/polaris/cosmos/lib"
 	evmtypes "pkg.berachain.dev/polaris/cosmos/x/evm/types"
 	"pkg.berachain.dev/polaris/eth/common"
 	coretypes "pkg.berachain.dev/polaris/eth/core/types"
@@ -122,32 +126,29 @@ func (etp *EthTxPool) Nonce(addr common.Address) uint64 {
 	pendingNonces := make(map[common.Address]uint64)
 	etp.mu.Lock()
 
-	// search for the first pending ethTx
+	// search for the last pending tx for the given address
 	for iter := etp.PriorityNonceMempool.Select(context.Background(), nil); iter != nil; iter = iter.Next() {
-		if ethTx := evmtypes.GetAsEthTx(iter.Tx()); ethTx != nil {
-			txAddr := coretypes.GetSender(ethTx)
-			if addr != txAddr {
-				continue
+		txAddr, txNonce := getTxSenderNonce(iter.Tx())
+		if addr != txAddr {
+			continue
+		}
+		pendingNonce, ok := pendingNonces[addr]
+		switch {
+		case !ok:
+			// If on the first lookup the nonce delta is more than 0, then there is a gap
+			// and thus no pending transactions, but there are queued transactions.
+			if sdbNonce := etp.nr.GetNonce(addr); txNonce-sdbNonce >= 1 {
+				return sdbNonce
 			}
-			pendingNonce, ok := pendingNonces[addr]
-			txNonce := ethTx.Nonce()
-			switch {
-			case !ok:
-				// If on the first lookup the nonce delta is more than 0, then there is a gap
-				// and thus no pending transactions, but there are queued transactions.
-				if sdbNonce := etp.nr.GetNonce(addr); txNonce-sdbNonce >= 1 {
-					return sdbNonce
-				}
-				// this is a pending tx, add it to the pending map.
-				pendingNonces[addr] = txNonce
-			case txNonce == pendingNonce+1:
-				// If we are still contiguous and the nonce is the same as the pending nonce,
-				// increment the pending nonce.
-				pendingNonces[addr]++
-			case txNonce > pendingNonce+1:
-				// As soon as we see a non contiguous nonce we break.
-				break
-			}
+			// this is a pending tx, add it to the pending map.
+			pendingNonces[addr] = txNonce
+		case txNonce == pendingNonce+1:
+			// If we are still contiguous and the nonce is the same as the pending nonce,
+			// increment the pending nonce.
+			pendingNonces[addr]++
+		case txNonce > pendingNonce+1:
+			// As soon as we see a non contiguous nonce we break.
+			break
 		}
 	}
 
@@ -193,4 +194,13 @@ func (etp *EthTxPool) Content() (
 	map[common.Address]coretypes.Transactions, map[common.Address]coretypes.Transactions,
 ) {
 	return etp.Pending(false), etp.queued()
+}
+
+// getTxSenderNonce returns the sender address (as an Eth address) and the nonce of the given tx.
+func getTxSenderNonce(tx sdk.Tx) (common.Address, uint64) {
+	sigs, err := tx.(signing.SigVerifiableTx).GetSignaturesV2()
+	if err != nil || len(sigs) == 0 {
+		panic("yay")
+	}
+	return cosmlib.AccAddressToEthAddress(sdk.AccAddress(sigs[0].PubKey.Address())), sigs[0].Sequence
 }

--- a/cosmos/x/evm/plugins/txpool/mempool/mempool_test.go
+++ b/cosmos/x/evm/plugins/txpool/mempool/mempool_test.go
@@ -373,17 +373,21 @@ var _ = Describe("EthTxPool", func() {
 		})
 		It("should break out of func Nonce(addr) when seeing a noncontigious nonce gap", func() {
 			_, tx1 := buildTx(key1, &coretypes.LegacyTx{Nonce: 1})
-			_, tx2 := buildTx(key1, &coretypes.LegacyTx{Nonce: 2})
+			tx2 := buildSdkTx(key1, 2)
 			_, tx3 := buildTx(key1, &coretypes.LegacyTx{Nonce: 3})
 			_, tx10 := buildTx(key1, &coretypes.LegacyTx{Nonce: 10})
 
 			Expect(etp.Insert(ctx, tx1)).ToNot(HaveOccurred())
-			Expect(etp.Insert(ctx, tx2)).ToNot(HaveOccurred())
-			Expect(etp.Insert(ctx, tx3)).ToNot(HaveOccurred())
-			Expect(etp.Insert(ctx, tx10)).ToNot(HaveOccurred())
-			Expect(etp.Nonce(addr1)).To(BeEquivalentTo(4))
-			Expect(etp.Nonce(addr1)).ToNot(BeEquivalentTo(10))
+			Expect(etp.Nonce(addr1)).To(BeEquivalentTo(2))
 
+			Expect(etp.Insert(ctx, tx2)).ToNot(HaveOccurred())
+			Expect(etp.Nonce(addr1)).To(BeEquivalentTo(3))
+
+			Expect(etp.Insert(ctx, tx3)).ToNot(HaveOccurred())
+			Expect(etp.Nonce(addr1)).To(BeEquivalentTo(4))
+
+			Expect(etp.Insert(ctx, tx10)).ToNot(HaveOccurred())
+			Expect(etp.Nonce(addr1)).To(BeEquivalentTo(4)) // should not be 10
 		})
 
 	})
@@ -429,6 +433,23 @@ func isPendingTx(mempool *EthTxPool, tx *coretypes.Transaction) bool {
 		}
 	}
 	return false
+}
+
+func buildSdkTx(from *ecdsa.PrivateKey, nonce uint64) sdk.Tx {
+	pubKey := &ethsecp256k1.PubKey{Key: crypto.CompressPubkey(&from.PublicKey)}
+	signer := crypto.PubkeyToAddress(from.PublicKey)
+	return &mockSdkTx{
+		signers: []sdk.AccAddress{cosmlib.AddressToAccAddress(signer)},
+		msgs:    []sdk.Msg{},
+		pubKeys: []cryptotypes.PubKey{pubKey},
+		signatures: []signing.SignatureV2{
+			{
+				PubKey: pubKey,
+				// NOTE: not including the signature data for the mock
+				Sequence: nonce,
+			},
+		},
+	}
 }
 
 func buildTx(from *ecdsa.PrivateKey, txData coretypes.TxData) (*coretypes.Transaction, sdk.Tx) {

--- a/cosmos/x/evm/types/tx.go
+++ b/cosmos/x/evm/types/tx.go
@@ -136,6 +136,9 @@ func (etr *WrappedEthereumTransaction) ValidateBasic() error {
 
 // GetAsEthTx is a helper function to get an EthTx from a sdk.Tx.
 func GetAsEthTx(tx sdk.Tx) *coretypes.Transaction {
+	if len(tx.GetMsgs()) == 0 {
+		return nil
+	}
 	etr, ok := utils.GetAs[*WrappedEthereumTransaction](tx.GetMsgs()[0])
 	if !ok {
 		return nil


### PR DESCRIPTION
fixing issue:
"the case in which it could return the wrong pending nonce is if you send in E, C, E txs. Say the first Eth tx sends in a nonce x. The next tx, Cosmos tx has a sequence/nonce of x+1. Now before sending the next tx, the eth client asks for pending nonce and currently, it will still return x+1 as pending because its only using the eth txs. So now you have 2 txs with nonce x+1 , so depending on ordering one of them will fail during processing."