### PR TITLE
eip1155 chain-id updated from 69420 -> 2061

### DIFF
--- a/cosmos/testing/integration/graphql/graphql_test.go
+++ b/cosmos/testing/integration/graphql/graphql_test.go
@@ -356,7 +356,7 @@ var _ = Describe("GraphQL", func() {
 			big.NewInt(10), // Gas price
 			nil,
 		)
-		signed, err := types.SignTx(tx, types.NewLondonSigner(big.NewInt(69420)), alicePrivKey)
+		signed, err := types.SignTx(tx, types.NewLondonSigner(big.NewInt(2061)), alicePrivKey)
 		Expect(err).ToNot(HaveOccurred())
 		rlpEncoded, err := rlp.EncodeToBytes(signed)
 		Expect(err).ToNot(HaveOccurred())

--- a/cosmos/testing/integration/jsonrpc/eth_test.go
+++ b/cosmos/testing/integration/jsonrpc/eth_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Network", func() {
 
 	It("should support eth_chainId", func() {
 		chainID, err := client.ChainID(ctx)
-		Expect(chainID.String()).To(Equal("69420"))
+		Expect(chainID.String()).To(Equal("2061"))
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/cosmos/x/evm/types/params_test.go
+++ b/cosmos/x/evm/types/params_test.go
@@ -31,6 +31,6 @@ var _ = Describe("Test Params", func() {
 	It("should marshal chain config correctly", func() {
 		params := DefaultParams()
 		ethConfig := params.EthereumChainConfig()
-		Expect(ethConfig.ChainID).To(Equal(big.NewInt(69420)))
+		Expect(ethConfig.ChainID).To(Equal(big.NewInt(2061)))
 	})
 })

--- a/docs/web/pages/docs/for-frontend-devs/chain-config.mdx
+++ b/docs/web/pages/docs/for-frontend-devs/chain-config.mdx
@@ -7,7 +7,7 @@ environments.
 ### JSON RPC Configuration
 - Network Name: `Polaris Ethereum`
 - RPC URL: `http://localhost:8545`
-- Chain ID: `69420`
+- Chain ID: `2061`
 - Symbol(optional): `BERA`
 - Block Explorer URL (optional): ``
 

--- a/docs/web/pages/docs/for-frontend-devs/staking-example.mdx
+++ b/docs/web/pages/docs/for-frontend-devs/staking-example.mdx
@@ -188,7 +188,7 @@ import { metaMaskWallet } from '@rainbow-me/rainbowkit/wallets';
 
 // Configure chain information for local Polaris Ethereum chain
 const polarisChain: Chain = {
-  id: 69420,
+  id: 2061,
   name: 'Polaris Ethereum's,
   network: 'polaris',
   nativeCurrency: {

--- a/docs/web/pages/docs/using-metamask.mdx
+++ b/docs/web/pages/docs/using-metamask.mdx
@@ -28,7 +28,7 @@ Now, we need to input the following values/
 
 - Network Name: `Polaris Ethereum`
 - New RPC URL: `http://localhost:8545`
-- Chain ID: `69420`
+- Chain ID: `2061`
 - Symbol(optional): `BERA`
 - Block Explorer URL (optional): ``
 

--- a/eth/params/chain_config.go
+++ b/eth/params/chain_config.go
@@ -24,7 +24,7 @@ import (
 	"math/big"
 )
 
-const DefaultEIP155ChainID = 69420
+const DefaultEIP155ChainID = 2061
 
 var zero = uint64(0)
 


### PR DESCRIPTION
Keplr parses evm chain Id based on the ending numbers in the cosmos chain-id. As a temp solution prior to submitting a refactoring PR to keplr wallet in order to change this, the last four digits of our cosmos chain id now matches our evm chain id. This change is required for keplr to submit eth transactions to our JSON-RPC endpoint.