### PR TITLE
fix(chain): Reduce in-memory cache size

### DIFF
--- a/eth/core/chain.go
+++ b/eth/core/chain.go
@@ -35,7 +35,7 @@ import (
 )
 
 // By default we are storing up to 256 items in each cache.
-const defaultCacheSize = 256
+const defaultCacheSize = 1024
 
 // Compile-time check to ensure that `blockchain` implements the `Blockchain` api.
 var _ Blockchain = (*blockchain)(nil)

--- a/eth/core/chain.go
+++ b/eth/core/chain.go
@@ -34,8 +34,8 @@ import (
 	"pkg.berachain.dev/polaris/eth/params"
 )
 
-// By default we are storing up to 64mb of historical data for each cache.
-const defaultCacheSizeBytes = 1024 * 1024 * 64
+// By default we are storing up to 256 items in each cache.
+const defaultCacheSize = 256
 
 // Compile-time check to ensure that `blockchain` implements the `Blockchain` api.
 var _ Blockchain = (*blockchain)(nil)
@@ -113,10 +113,10 @@ func NewChain(host PolarisHostChain) *blockchain { //nolint:revive // only used 
 		sp:             host.GetStatePlugin(),
 		tp:             host.GetTxPoolPlugin(),
 		vmConfig:       &vm.Config{},
-		receiptsCache:  lru.NewCache[common.Hash, types.Receipts](defaultCacheSizeBytes),
-		blockNumCache:  lru.NewCache[uint64, *types.Block](defaultCacheSizeBytes),
-		blockHashCache: lru.NewCache[common.Hash, *types.Block](defaultCacheSizeBytes),
-		txLookupCache:  lru.NewCache[common.Hash, *types.TxLookupEntry](defaultCacheSizeBytes),
+		receiptsCache:  lru.NewCache[common.Hash, types.Receipts](defaultCacheSize),
+		blockNumCache:  lru.NewCache[uint64, *types.Block](defaultCacheSize),
+		blockHashCache: lru.NewCache[common.Hash, *types.Block](defaultCacheSize),
+		txLookupCache:  lru.NewCache[common.Hash, *types.TxLookupEntry](defaultCacheSize),
 		chainHeadFeed:  event.Feed{},
 		scope:          event.SubscriptionScope{},
 		logger:         log.Root(),

--- a/eth/core/chain.go
+++ b/eth/core/chain.go
@@ -34,7 +34,7 @@ import (
 	"pkg.berachain.dev/polaris/eth/params"
 )
 
-// By default we are storing up to 256 items in each cache.
+// By default we are storing up to 1024 items in each cache.
 const defaultCacheSize = 1024
 
 // Compile-time check to ensure that `blockchain` implements the `Blockchain` api.


### PR DESCRIPTION
the cache size was not actually 64 mb but storing ~67 million items. caches were causing node memory to grow very high. @pentaful1 @BrickBera @transmissions12 