### PR TITLE
fix: evm contract missing in app_state.evm.alloc when exporting genesis.json

### DIFF
--- a/cosmos/x/evm/plugins/state/genesis.go
+++ b/cosmos/x/evm/plugins/state/genesis.go
@@ -82,6 +82,11 @@ func (p *plugin) ExportGenesis(ctx sdk.Context, ethGen *core.Genesis) {
 			account.Storage = make(map[common.Hash]common.Hash)
 		}
 		account.Storage[key] = value
+
+		account.Code = p.GetCode(address)
+		account.Balance = p.GetBalance(address)
+		ethGen.Alloc[address] = account
+
 		return false
 	})
 }


### PR DESCRIPTION
Henlo! This PR is to fix exporting genesis command. It seems if evm contract's balance is 0 (or contract's key with BalanceKeyPrefix doesn't exist in KVStore), the contract's info doesn't exported.
In previous code, account is only stored in `ethGen.Alloc[address]` when processing `IterateBalances` step. But if contract has no balance, it's address cannot iterate in this step. 
So i want to suggest storing account(core.GenesisAccount) in `ethGen.Alloc[address]` with code and balance when processing `IterateState` step also. 

Please let me know if it's working as intended. Thx. :)

### Before
## 1. Deploy contract with deposit (payable function)
contract address: `0x18Df82C7E422A42D47345Ed86B0E935E9718eBda`
<img width="953" alt="Screenshot 2023-08-30 at 6 25 20 PM" src="https://github.com/berachain/polaris/assets/22219576/fdab3f36-ce2f-4991-a043-1fa15b3d3f50">

## 2. Deploy contract without deposit
contract address: `0x3945f611Fe77A51C7F3e1f84709C1a2fDcDfAC5B`
<img width="1318" alt="Screenshot 2023-08-30 at 6 25 42 PM" src="https://github.com/berachain/polaris/assets/22219576/52571df1-9ab0-4208-a7de-dbbe555c982c">

## 3. In genesis.json file
Only 1st contract appears in genesis.json
Command to export genesis: `bin/polard export --for-zero-height --home "./.tmp/polard" --output-document genesis.json`
<img width="1244" alt="Screenshot 2023-08-30 at 6 27 16 PM" src="https://github.com/berachain/polaris/assets/22219576/7fb5a11b-1373-4925-9599-2963b7b4b0af">

### After
## 1. Deploy contract with deposit
contract address: `0x18Df82C7E422A42D47345Ed86B0E935E9718eBda`
<img width="1315" alt="Screenshot 2023-08-30 at 6 28 49 PM" src="https://github.com/berachain/polaris/assets/22219576/c20ca6d1-0a35-4cf7-b0c4-23386dc532e9">

## 2. Deploy contract without deposit
contract address: `0x3945f611Fe77A51C7F3e1f84709C1a2fDcDfAC5B`
<img width="1321" alt="Screenshot 2023-08-30 at 6 29 06 PM" src="https://github.com/berachain/polaris/assets/22219576/c98aaf6b-5138-471b-b4fa-feeb59394227">

## 3. In genesis.json file
1st and 2nd contract appear in genesis.json
Command to export genesis: `bin/polard export --for-zero-height --home "./.tmp/polard" -
<img width="1244" alt="Screenshot 2023-08-30 at 6 30 52 PM" src="https://github.com/berachain/polaris/assets/22219576/1130b8a6-265b-46ad-976d-1d022845150b">
-output-document genesis.json`


