### PR TITLE
fix(pc): Enforce read-only at the container level

### DIFF
--- a/contracts/bindings/testing/mock_precompile_interface.abigen.go
+++ b/contracts/bindings/testing/mock_precompile_interface.abigen.go
@@ -37,7 +37,7 @@ type MockPrecompileInterfaceObject struct {
 
 // MockPrecompileMetaData contains all meta data concerning the MockPrecompile contract.
 var MockPrecompileMetaData = &bind.MetaData{
-	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"contractFunc\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"ans\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"contractFuncStr\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"getOutput\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"timeStamp\",\"type\":\"string\"}],\"internalType\":\"structMockPrecompileInterface.Object[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getOutputPartial\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"timeStamp\",\"type\":\"string\"}],\"internalType\":\"structMockPrecompileInterface.Object\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"overloadedFunc\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"ans\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"a\",\"type\":\"uint256\"}],\"name\":\"overloadedFunc\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"ans\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"addr\",\"type\":\"address\"}],\"name\":\"contractFunc\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"ans\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"contractFuncStr\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"str\",\"type\":\"string\"}],\"name\":\"getOutput\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"timeStamp\",\"type\":\"string\"}],\"internalType\":\"structMockPrecompileInterface.Object[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getOutputPartial\",\"outputs\":[{\"components\":[{\"internalType\":\"uint256\",\"name\":\"creationHeight\",\"type\":\"uint256\"},{\"internalType\":\"string\",\"name\":\"timeStamp\",\"type\":\"string\"}],\"internalType\":\"structMockPrecompileInterface.Object\",\"name\":\"\",\"type\":\"tuple\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"overloadedFunc\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"ans\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"a\",\"type\":\"uint256\"}],\"name\":\"overloadedFunc\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"ans\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
 }
 
 // MockPrecompileABI is the input ABI used to generate the binding from.
@@ -186,6 +186,68 @@ func (_MockPrecompile *MockPrecompileTransactorRaw) Transact(opts *bind.Transact
 	return _MockPrecompile.Contract.contract.Transact(opts, method, params...)
 }
 
+// GetOutput is a free data retrieval call binding the contract method 0xb5c11fc2.
+//
+// Solidity: function getOutput(string str) view returns((uint256,string)[])
+func (_MockPrecompile *MockPrecompileCaller) GetOutput(opts *bind.CallOpts, str string) ([]MockPrecompileInterfaceObject, error) {
+	var out []interface{}
+	err := _MockPrecompile.contract.Call(opts, &out, "getOutput", str)
+
+	if err != nil {
+		return *new([]MockPrecompileInterfaceObject), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new([]MockPrecompileInterfaceObject)).(*[]MockPrecompileInterfaceObject)
+
+	return out0, err
+
+}
+
+// GetOutput is a free data retrieval call binding the contract method 0xb5c11fc2.
+//
+// Solidity: function getOutput(string str) view returns((uint256,string)[])
+func (_MockPrecompile *MockPrecompileSession) GetOutput(str string) ([]MockPrecompileInterfaceObject, error) {
+	return _MockPrecompile.Contract.GetOutput(&_MockPrecompile.CallOpts, str)
+}
+
+// GetOutput is a free data retrieval call binding the contract method 0xb5c11fc2.
+//
+// Solidity: function getOutput(string str) view returns((uint256,string)[])
+func (_MockPrecompile *MockPrecompileCallerSession) GetOutput(str string) ([]MockPrecompileInterfaceObject, error) {
+	return _MockPrecompile.Contract.GetOutput(&_MockPrecompile.CallOpts, str)
+}
+
+// GetOutputPartial is a free data retrieval call binding the contract method 0x7acaaeb9.
+//
+// Solidity: function getOutputPartial() view returns((uint256,string))
+func (_MockPrecompile *MockPrecompileCaller) GetOutputPartial(opts *bind.CallOpts) (MockPrecompileInterfaceObject, error) {
+	var out []interface{}
+	err := _MockPrecompile.contract.Call(opts, &out, "getOutputPartial")
+
+	if err != nil {
+		return *new(MockPrecompileInterfaceObject), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(MockPrecompileInterfaceObject)).(*MockPrecompileInterfaceObject)
+
+	return out0, err
+
+}
+
+// GetOutputPartial is a free data retrieval call binding the contract method 0x7acaaeb9.
+//
+// Solidity: function getOutputPartial() view returns((uint256,string))
+func (_MockPrecompile *MockPrecompileSession) GetOutputPartial() (MockPrecompileInterfaceObject, error) {
+	return _MockPrecompile.Contract.GetOutputPartial(&_MockPrecompile.CallOpts)
+}
+
+// GetOutputPartial is a free data retrieval call binding the contract method 0x7acaaeb9.
+//
+// Solidity: function getOutputPartial() view returns((uint256,string))
+func (_MockPrecompile *MockPrecompileCallerSession) GetOutputPartial() (MockPrecompileInterfaceObject, error) {
+	return _MockPrecompile.Contract.GetOutputPartial(&_MockPrecompile.CallOpts)
+}
+
 // ContractFunc is a paid mutator transaction binding the contract method 0xc7dda0b9.
 //
 // Solidity: function contractFunc(address addr) returns(uint256 ans)
@@ -226,48 +288,6 @@ func (_MockPrecompile *MockPrecompileSession) ContractFuncStr(str string) (*type
 // Solidity: function contractFuncStr(string str) returns(bool)
 func (_MockPrecompile *MockPrecompileTransactorSession) ContractFuncStr(str string) (*types.Transaction, error) {
 	return _MockPrecompile.Contract.ContractFuncStr(&_MockPrecompile.TransactOpts, str)
-}
-
-// GetOutput is a paid mutator transaction binding the contract method 0xb5c11fc2.
-//
-// Solidity: function getOutput(string str) returns((uint256,string)[])
-func (_MockPrecompile *MockPrecompileTransactor) GetOutput(opts *bind.TransactOpts, str string) (*types.Transaction, error) {
-	return _MockPrecompile.contract.Transact(opts, "getOutput", str)
-}
-
-// GetOutput is a paid mutator transaction binding the contract method 0xb5c11fc2.
-//
-// Solidity: function getOutput(string str) returns((uint256,string)[])
-func (_MockPrecompile *MockPrecompileSession) GetOutput(str string) (*types.Transaction, error) {
-	return _MockPrecompile.Contract.GetOutput(&_MockPrecompile.TransactOpts, str)
-}
-
-// GetOutput is a paid mutator transaction binding the contract method 0xb5c11fc2.
-//
-// Solidity: function getOutput(string str) returns((uint256,string)[])
-func (_MockPrecompile *MockPrecompileTransactorSession) GetOutput(str string) (*types.Transaction, error) {
-	return _MockPrecompile.Contract.GetOutput(&_MockPrecompile.TransactOpts, str)
-}
-
-// GetOutputPartial is a paid mutator transaction binding the contract method 0x7acaaeb9.
-//
-// Solidity: function getOutputPartial() returns((uint256,string))
-func (_MockPrecompile *MockPrecompileTransactor) GetOutputPartial(opts *bind.TransactOpts) (*types.Transaction, error) {
-	return _MockPrecompile.contract.Transact(opts, "getOutputPartial")
-}
-
-// GetOutputPartial is a paid mutator transaction binding the contract method 0x7acaaeb9.
-//
-// Solidity: function getOutputPartial() returns((uint256,string))
-func (_MockPrecompile *MockPrecompileSession) GetOutputPartial() (*types.Transaction, error) {
-	return _MockPrecompile.Contract.GetOutputPartial(&_MockPrecompile.TransactOpts)
-}
-
-// GetOutputPartial is a paid mutator transaction binding the contract method 0x7acaaeb9.
-//
-// Solidity: function getOutputPartial() returns((uint256,string))
-func (_MockPrecompile *MockPrecompileTransactorSession) GetOutputPartial() (*types.Transaction, error) {
-	return _MockPrecompile.Contract.GetOutputPartial(&_MockPrecompile.TransactOpts)
 }
 
 // OverloadedFunc is a paid mutator transaction binding the contract method 0x1e61d5aa.

--- a/contracts/src/testing/MockPrecompileInterface.sol
+++ b/contracts/src/testing/MockPrecompileInterface.sol
@@ -31,9 +31,9 @@ interface MockPrecompileInterface {
         string timeStamp;
     }
 
-    function getOutput(string calldata str) external returns (Object[] calldata);
+    function getOutput(string calldata str) external view returns (Object[] calldata);
 
-    function getOutputPartial() external returns (Object calldata);
+    function getOutputPartial() external view returns (Object calldata);
 
     function contractFunc(address addr) external returns (uint256 ans);
 

--- a/cosmos/precompile/distribution/distribution.go
+++ b/cosmos/precompile/distribution/distribution.go
@@ -25,7 +25,6 @@ import (
 
 	"cosmossdk.io/core/address"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 
 	"pkg.berachain.dev/polaris/contracts/bindings/cosmos/lib"
@@ -176,12 +175,8 @@ func (c *Contract) GetAllDelegatorRewards(
 		return nil, err
 	}
 
-	// NOTE: CacheContext is necessary here because this is a view method (EVM static call), but
-	// the Cosmos SDK distribution module's querier performs writes to the context kv stores. The
-	// cache context is never committed and discarded after this function call.
-	cacheCtx, _ := sdk.UnwrapSDKContext(ctx).CacheContext()
 	res, err := c.querier.DelegationTotalRewards( // performs writes to the context kv stores
-		cacheCtx,
+		ctx,
 		&distributiontypes.QueryDelegationTotalRewardsRequest{
 			DelegatorAddress: delAddr,
 		},
@@ -224,12 +219,8 @@ func (c *Contract) GetTotalDelegatorReward(
 		return nil, err
 	}
 
-	// NOTE: CacheContext is necessary here because this is a view method (EVM static call), but
-	// the Cosmos SDK distribution module's querier performs writes to the context kv stores. The
-	// cache context is never committed and discarded after this function call.
-	cacheCtx, _ := sdk.UnwrapSDKContext(ctx).CacheContext()
 	res, err := c.querier.DelegationTotalRewards( // performs writes to the context kv stores
-		cacheCtx,
+		ctx,
 		&distributiontypes.QueryDelegationTotalRewardsRequest{
 			DelegatorAddress: delAddr,
 		},

--- a/eth/core/precompile/stateful_container.go
+++ b/eth/core/precompile/stateful_container.go
@@ -83,7 +83,8 @@ func (sc *statefulContainer) Run(
 	}
 
 	// If the method is read-only (view/pure), snapshot so any state changes made during the call
-	// are not persisted.
+	// are not persisted. NOTE: this may not be the best place to handle state mutability, but it
+	// gets the job done.
 	if method.abiMethod.IsConstant() {
 		sdb := evm.GetStateDB()
 		snapshot := sdb.Snapshot()

--- a/eth/core/precompile/stateful_container.go
+++ b/eth/core/precompile/stateful_container.go
@@ -82,11 +82,12 @@ func (sc *statefulContainer) Run(
 		return nil, ErrMethodNotFound
 	}
 
-	// If the method is read-only (view/pure), snapshot so any state changes after the call are not
-	// persisted.
+	// If the method is read-only (view/pure), snapshot so any state changes made during the call
+	// are not persisted.
 	if method.abiMethod.IsConstant() {
-		snapshot := evm.GetStateDB().Snapshot()
-		defer func() { evm.GetStateDB().RevertToSnapshot(snapshot) }()
+		sdb := evm.GetStateDB()
+		snapshot := sdb.Snapshot()
+		defer func() { sdb.RevertToSnapshot(snapshot) }()
 	}
 
 	// Execute the method with the reflected ctx and raw input

--- a/eth/core/precompile/stateful_container_test.go
+++ b/eth/core/precompile/stateful_container_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Stateful Container", func() {
 			))
 		})
 
-		FIt("should return properly for valid method calls", func() {
+		It("should return properly for valid method calls", func() {
 			var inputs []byte
 			inputs, err = getOutputABI.Inputs.Pack("string")
 			Expect(err).ToNot(HaveOccurred())

--- a/eth/core/precompile/stateful_container_test.go
+++ b/eth/core/precompile/stateful_container_test.go
@@ -111,10 +111,11 @@ var _ = Describe("Stateful Container", func() {
 			))
 		})
 
-		It("should return properly for valid method calls", func() {
+		FIt("should return properly for valid method calls", func() {
 			var inputs []byte
 			inputs, err = getOutputABI.Inputs.Pack("string")
 			Expect(err).ToNot(HaveOccurred())
+
 			var ret []byte
 			ret, err = sc.Run(
 				ctx,
@@ -124,6 +125,7 @@ var _ = Describe("Stateful Container", func() {
 				vm.UnwrapPolarContext(ctx).MsgValue(),
 			)
 			Expect(err).ToNot(HaveOccurred())
+
 			var outputs []interface{}
 			outputs, err = getOutputABI.Outputs.Unpack(ret)
 			Expect(err).ToNot(HaveOccurred())
@@ -137,6 +139,10 @@ var _ = Describe("Stateful Container", func() {
 			Expect(
 				reflect.ValueOf(outputs[0]).Index(0).FieldByName("TimeStamp").Interface().(string),
 			).To(Equal("string"))
+
+			// view method should not be able to add logs to the statedb
+			Expect(vm.UnwrapPolarContext(ctx).Evm().GetStateDB().GetLogs(
+				common.Hash{}, 0, common.Hash{})).To(BeEmpty())
 		})
 	})
 })

--- a/eth/core/vm/mock/statedb.go
+++ b/eth/core/vm/mock/statedb.go
@@ -138,11 +138,11 @@ func NewEmptyStateDB() *PolarisStateDBMock {
 		},
 	}
 	mockedPolarisStateDB.LogsFunc = func() []*types.Log {
-		logs := []*types.Log{}
+		ret := []*types.Log{}
 		for _, l := range mockedPolarisStateDB.AddLogCalls() {
-			logs = append(logs, l.Log)
+			ret = append(ret, l.Log)
 		}
-		return logs
+		return ret
 	}
 	return mockedPolarisStateDB
 }

--- a/eth/core/vm/mock/statedb.go
+++ b/eth/core/vm/mock/statedb.go
@@ -33,6 +33,7 @@ import (
 
 // NewEmptyStateDB creates a new `StateDBMock` instance.
 func NewEmptyStateDB() *PolarisStateDBMock {
+	logs := []*types.Log{}
 	mockedPolarisStateDB := &PolarisStateDBMock{
 		AddAddressToAccessListFunc: func(addr common.Address) {
 
@@ -41,7 +42,7 @@ func NewEmptyStateDB() *PolarisStateDBMock {
 
 		},
 		AddLogFunc: func(log *types.Log) {
-
+			logs = append(logs, log)
 		},
 		AddPreimageFunc: func(hash common.Hash, bytes []byte) {
 
@@ -89,7 +90,7 @@ func NewEmptyStateDB() *PolarisStateDBMock {
 			return common.Hash{}
 		},
 		GetLogsFunc: func(hash common.Hash, blockNumber uint64, blockHash common.Hash) []*types.Log {
-			return []*types.Log{}
+			return logs
 		},
 		GetNonceFunc: func(address common.Address) uint64 {
 			return 0
@@ -110,7 +111,7 @@ func NewEmptyStateDB() *PolarisStateDBMock {
 			// no-op
 		},
 		RevertToSnapshotFunc: func(n int) {
-
+			logs = []*types.Log{}
 		},
 		SetCodeFunc: func(address common.Address, bytes []byte) {
 


### PR DESCRIPTION
Snapshot before and revertToSnapshot after execution of view/pure method; can remove cacheContexts