### PR TITLE
fix(statedb): Logs `clone` was not correct.

### DIFF
--- a/eth/core/state/journal/logs.go
+++ b/eth/core/state/journal/logs.go
@@ -132,9 +132,10 @@ func (l *logs) Finalize() {}
 
 // Clone implements `libtypes.Cloneable`.
 func (l *logs) Clone() Log {
+	capacity := l.Capacity()
 	size := l.Size()
 	clone := &logs{
-		Stack:   stack.New[*coretypes.Log](size),
+		Stack:   stack.New[*coretypes.Log](capacity),
 		txHash:  l.txHash,
 		txIndex: l.txIndex,
 	}

--- a/lib/ds/stack/stack.go
+++ b/lib/ds/stack/stack.go
@@ -27,16 +27,18 @@ const (
 // stack is a struct that holds a slice of Items as a last in, first out data structure.
 // It is implemented by pre-allocating a buffer with a capacity.
 type stack[T any] struct {
-	size     int
-	capacity int
-	buf      []T
+	size            int
+	capacity        int
+	initialCapacity int
+	buf             []T
 }
 
 // Creates a new, empty stack with the given initial capacity.
 func New[T any](initialCapacity int) ds.Stack[T] {
 	return &stack[T]{
-		capacity: initialCapacity,
-		buf:      make([]T, initialCapacity),
+		capacity:        initialCapacity,
+		buf:             make([]T, initialCapacity),
+		initialCapacity: initialCapacity,
 	}
 }
 
@@ -105,15 +107,15 @@ func (s *stack[T]) expandIfRequired() {
 	if s.size < s.capacity {
 		return
 	}
-
-	newBuf := make([]T, (s.capacity*resizeRatio)/two)
+	newCapacity := max(s.initialCapacity, (s.capacity*resizeRatio)/two)
+	newBuf := make([]T, newCapacity)
 	s.buf = append(s.buf, newBuf...)
 	s.capacity *= resizeRatio
 }
 
 // shrinkIfRequired shrinks the stack if the size is less than the capacity/resizeRatio.
 func (s *stack[T]) shrinkIfRequired() {
-	if newCap := s.capacity / resizeRatio; s.size < newCap {
+	if newCap := max(s.initialCapacity, s.capacity/resizeRatio); s.size < newCap {
 		newBuf := make([]T, newCap)
 		copy(newBuf, s.buf)
 		s.buf = newBuf

--- a/lib/ds/stack/stack.go
+++ b/lib/ds/stack/stack.go
@@ -108,17 +108,16 @@ func (s *stack[T]) expandIfRequired() {
 		return
 	}
 	newCapacity := max(s.initialCapacity, (s.capacity*resizeRatio)/two)
-	newBuf := make([]T, newCapacity)
-	s.buf = append(s.buf, newBuf...)
+	s.buf = append(s.buf, make([]T, newCapacity)...)
 	s.capacity *= resizeRatio
 }
 
 // shrinkIfRequired shrinks the stack if the size is less than the capacity/resizeRatio.
 func (s *stack[T]) shrinkIfRequired() {
-	if newCap := max(s.initialCapacity, s.capacity/resizeRatio); s.size < newCap {
-		newBuf := make([]T, newCap)
+	if newCapacity := max(s.initialCapacity, s.capacity/resizeRatio); s.size < newCapacity {
+		newBuf := make([]T, newCapacity)
 		copy(newBuf, s.buf)
 		s.buf = newBuf
-		s.capacity = newCap
+		s.capacity = newCapacity
 	}
 }


### PR DESCRIPTION
Leads to StateByHeaderOrHash having a cloned logs journal size of 0 which is big bad. 