### PR TITLE
fix(actions): Adding token for docs repo access

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: berachain/docs-monorepo
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DOCS_TOKEN }}
           path: docs-monorepo
           ref: main
       - name: Set up Python


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the authentication token used in the GitHub Actions workflow. This change impacts the daily build process, specifically the repository checkout step. The new `DOCS_TOKEN` will be used for authentication, replacing the previous `GITHUB_TOKEN`. This internal update enhances the security and access control of our CI/CD pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->