### PR TITLE
fix(distr): filter empty rewards

### DIFF
--- a/cosmos/precompile/distribution/distribution.go
+++ b/cosmos/precompile/distribution/distribution.go
@@ -193,6 +193,9 @@ func (c *Contract) GetAllDelegatorRewards(
 	rewards := make([]generated.IDistributionModuleValidatorReward, 0, len(res.Rewards))
 	for _, reward := range res.Rewards {
 		var amount []generated.CosmosCoin
+		if reward.Reward.Len() == 0 {
+			continue
+		}
 		for _, coin := range reward.Reward {
 			amount = append(amount, generated.CosmosCoin{
 				Denom:  coin.Denom,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Optimized the `GetAllDelegatorRewards` function in the `Contract` struct of the `distribution.go` file. The update skips processing for delegator rewards that have an empty `Reward` field, enhancing system performance by avoiding unnecessary computations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->