### PR TITLE
fix(evm): Emit Eth chain events only after current block is committed to chain state

### DIFF
--- a/cosmos/x/evm/keeper/abci.go
+++ b/cosmos/x/evm/keeper/abci.go
@@ -34,7 +34,12 @@ func (k *Keeper) BeginBlocker(ctx context.Context) error {
 	return nil
 }
 
-func (k *Keeper) EndBlock(ctx context.Context) error {
+func (k *Keeper) EndBlock() error {
 	// Finalize the Polaris Ethereum block.
-	return k.miner.Finalize(ctx)
+	return k.miner.Finalize()
+}
+
+func (k *Keeper) PrepareCheckState() error {
+	// Run the Polaris miner's post commit hook.
+	return k.miner.PostCommitHook()
 }

--- a/cosmos/x/evm/keeper/processor_test.go
+++ b/cosmos/x/evm/keeper/processor_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Processor", func() {
 		})
 
 		AfterEach(func() {
-			err := k.EndBlock(ctx)
+			err := k.EndBlock()
 			Expect(err).ToNot(HaveOccurred())
 			err = os.RemoveAll("tmp/berachain")
 			Expect(err).ToNot(HaveOccurred())

--- a/cosmos/x/evm/module.go
+++ b/cosmos/x/evm/module.go
@@ -43,11 +43,12 @@ import (
 const ConsensusVersion = 1
 
 var (
-	_ appmodule.HasServices     = AppModule{}
-	_ appmodule.HasBeginBlocker = AppModule{}
-	_ appmodule.HasEndBlocker   = AppModule{}
-	_ module.AppModule          = AppModule{}
-	_ module.AppModuleBasic     = AppModuleBasic{}
+	_ appmodule.HasServices          = AppModule{}
+	_ appmodule.HasBeginBlocker      = AppModule{}
+	_ appmodule.HasEndBlocker        = AppModule{}
+	_ appmodule.HasPrepareCheckState = AppModule{}
+	_ module.AppModule               = AppModule{}
+	_ module.AppModuleBasic          = AppModuleBasic{}
 )
 
 // ==============================================================================
@@ -132,6 +133,11 @@ func (am AppModule) BeginBlock(ctx context.Context) error {
 }
 
 // EndBlock returns the end blocker for the evm module.
-func (am AppModule) EndBlock(ctx context.Context) error {
-	return am.keeper.EndBlock(ctx)
+func (am AppModule) EndBlock(context.Context) error {
+	return am.keeper.EndBlock()
+}
+
+// PrepareCheckState returns the prepare check stater for the evm module.
+func (am AppModule) PrepareCheckState(context.Context) error {
+	return am.keeper.PrepareCheckState()
 }

--- a/e2e/testapp/app_config.go
+++ b/e2e/testapp/app_config.go
@@ -147,6 +147,9 @@ func MakeAppConfig(bech32Prefix string) depinject.Config {
 						genutiltypes.ModuleName,
 						evmtypes.ModuleName,
 					},
+					PrepareCheckStaters: []string{
+						evmtypes.ModuleName,
+					},
 					OverrideStoreKeys: []*runtimev1alpha1.StoreKeyConfig{
 						{
 							ModuleName: authtypes.ModuleName,

--- a/eth/core/chain_subscriber.go
+++ b/eth/core/chain_subscriber.go
@@ -70,8 +70,8 @@ func (bc *blockchain) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Su
 // EmitCurrentBlockEvents emits chain events for the current block.
 func (bc *blockchain) EmitCurrentBlockEvents() {
 	// Send the pending/current logs on the logs feeds.
-	logs, ok := utils.GetAs[[]*types.Log](bc.currentLogs.Load())
-	if ok {
+	logs := utils.MustGetAs[[]*types.Log](bc.currentLogs.Load())
+	if logs != nil {
 		bc.pendingLogsFeed.Send(logs)
 		if len(logs) > 0 {
 			bc.logsFeed.Send(logs)
@@ -79,7 +79,7 @@ func (bc *blockchain) EmitCurrentBlockEvents() {
 	}
 
 	// Send the current block on the chain(head) feeds.
-	if block, ok := utils.GetAs[*types.Block](bc.currentBlock.Load()); ok {
+	if block := utils.MustGetAs[*types.Block](bc.currentBlock.Load()); block != nil {
 		bc.chainFeed.Send(ChainEvent{Block: block, Hash: block.Hash(), Logs: logs})
 		bc.chainHeadFeed.Send(ChainHeadEvent{Block: block})
 	}

--- a/eth/core/chain_writer.go
+++ b/eth/core/chain_writer.go
@@ -24,7 +24,7 @@ import (
 	"pkg.berachain.dev/polaris/eth/core/types"
 )
 
-// ChainWriter defines methods that are used to perform state and block transitions.
+// ChainWriter defines methods that are used to update the chain state.
 type ChainWriter interface {
 	InsertBlock(block *types.Block, receipts types.Receipts, logs []*types.Log) error
 }
@@ -69,16 +69,16 @@ func (bc *blockchain) InsertBlock(block *types.Block, receipts types.Receipts, l
 		}
 	}
 
-	// mark the current block, receipts, and logs
+	// Mark the current block, receipts, and logs (caches should only be set during reads).
 	if block != nil {
 		bc.currentBlock.Store(block)
 		bc.finalizedBlock.Store(block)
 
-		bc.blockNumCache.Add(blockNum, block)
-		bc.blockHashCache.Add(blockHash, block)
+		bc.blockNumCache.Add(blockNum, block)   // TODO: remove.
+		bc.blockHashCache.Add(blockHash, block) // TODO: remove.
 
 		for txIndex, tx := range block.Transactions() {
-			bc.txLookupCache.Add(
+			bc.txLookupCache.Add( // TODO: remove.
 				tx.Hash(),
 				&types.TxLookupEntry{
 					Tx:        tx,
@@ -91,14 +91,10 @@ func (bc *blockchain) InsertBlock(block *types.Block, receipts types.Receipts, l
 	}
 	if receipts != nil {
 		bc.currentReceipts.Store(receipts)
-		bc.receiptsCache.Add(blockHash, receipts)
+		bc.receiptsCache.Add(blockHash, receipts) // TODO: remove.
 	}
 	if logs != nil {
-		bc.pendingLogsFeed.Send(logs)
 		bc.currentLogs.Store(logs)
-		if len(logs) > 0 {
-			bc.logsFeed.Send(logs)
-		}
 	}
 
 	// Send chain events.

--- a/eth/core/processor.go
+++ b/eth/core/processor.go
@@ -150,9 +150,7 @@ func (sp *StateProcessor) ProcessTransaction(
 
 // Finalize finalizes the block in the state processor and returns the receipts and bloom filter to
 // be "sealed".
-func (sp *StateProcessor) Finalize(
-	_ context.Context,
-) (*types.Block, types.Receipts, []*types.Log, error) {
+func (sp *StateProcessor) Finalize() (*types.Block, types.Receipts, []*types.Log, error) {
 	// We unlock the state processor to ensure that the state is consistent.
 	defer sp.mtx.Unlock()
 

--- a/eth/core/processor_test.go
+++ b/eth/core/processor_test.go
@@ -93,7 +93,7 @@ var _ = Describe("StateProcessor", func() {
 
 	Context("Empty block", func() {
 		It("should build a an empty block", func() {
-			block, receipts, logs, err := sp.Finalize(context.Background())
+			block, receipts, logs, err := sp.Finalize()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(block).ToNot(BeNil())
 			Expect(receipts).To(BeEmpty())
@@ -103,7 +103,7 @@ var _ = Describe("StateProcessor", func() {
 
 	Context("Block with transactions", func() {
 		BeforeEach(func() {
-			_, _, _, err := sp.Finalize(context.Background())
+			_, _, _, err := sp.Finalize()
 			Expect(err).ToNot(HaveOccurred())
 			sp.Prepare(evm, dummyHeader)
 		})
@@ -113,7 +113,7 @@ var _ = Describe("StateProcessor", func() {
 			receipt, err := sp.ProcessTransaction(context.Background(), gasPool, types.NewTx(legacyTxData))
 			Expect(err).To(HaveOccurred())
 			Expect(receipt).To(BeNil())
-			block, receipts, logs, err := sp.Finalize(context.Background())
+			block, receipts, logs, err := sp.Finalize()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(block).ToNot(BeNil())
 			Expect(receipts).To(BeEmpty())
@@ -132,7 +132,7 @@ var _ = Describe("StateProcessor", func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result.Status).To(Equal(uint64(1)))
 			Expect(result.GasUsed).ToNot(BeZero())
-			block, receipts, logs, err := sp.Finalize(context.Background())
+			block, receipts, logs, err := sp.Finalize()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(block).ToNot(BeNil())
 			Expect(receipts).To(HaveLen(1))
@@ -176,7 +176,7 @@ var _ = Describe("StateProcessor", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).ToNot(BeNil())
 			Expect(result.Status).To(Equal(uint64(1)))
-			block, receipts, logs, err := sp.Finalize(context.Background())
+			block, receipts, logs, err := sp.Finalize()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(block).ToNot(BeNil())
 			Expect(receipts).To(HaveLen(2))

--- a/eth/polar/mining.go
+++ b/eth/polar/mining.go
@@ -41,6 +41,6 @@ func (pl *Polaris) ProcessTransaction(ctx context.Context, tx *types.Transaction
 }
 
 // Finalize finalizes the current block.
-func (pl *Polaris) Finalize(ctx context.Context) error {
-	return pl.miner.Finalize(ctx)
+func (pl *Polaris) Finalize() error {
+	return pl.miner.Finalize()
 }


### PR DESCRIPTION
To ensure for clients that any query of chain state (upon receiving a new block event) will include that same block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added `PostCommitHook()` method to the `Miner` interface and `miner` struct in `eth/miner/miner.go`, enabling additional operations after commit.
- Refactor: Updated `EndBlock` function across multiple files (`cosmos/x/evm/keeper/abci.go`, `cosmos/x/evm/keeper/processor_test.go`, `cosmos/x/evm/module.go`) to remove the `ctx` parameter, simplifying its usage.
- Refactor: Modified `Finalize` function in several files (`eth/core/processor.go`, `eth/polar/mining.go`, `eth/miner/miner.go`) to remove the `ctx` parameter and return an error, enhancing error handling.
- New Feature: Introduced `EmitCurrentBlockEvents()` function in `eth/core/chain_subscriber.go` for emitting chain events for the current block.
- Test: Adjusted test suites in `eth/core/processor_test.go` to reflect changes in `Finalize()` and `ProcessTransaction()` functions.
- Chore: Marked certain caching operations in `eth/core/chain_writer.go` for removal, indicating future optimization efforts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->