### PR TITLE
fix(script): fix scripts in docker

### DIFF
--- a/e2e/testapp/docker/seed/scripts/set-moniker.sh
+++ b/e2e/testapp/docker/seed/scripts/set-moniker.sh
@@ -21,22 +21,7 @@
 if [ -z "$HOMEDIR" ]; then
     HOMEDIR="/.polard"
 fi
-if [ -z "$KEYRING" ]; then
-    KEYRING="test"
-fi
-if [ -z "$KEYALGO" ]; then
-    KEYALGO="secp256k1"
-fi
+CONFIG_TOML=$HOMEDIR/config/config.toml
 
-polard genesis collect-gentxs --home "$HOMEDIR"
-
-polard genesis validate-genesis --home "$HOMEDIR"
-
-# # faucet
-# polard keys add faucet --keyring-backend $KEYRING --algo $KEYALGO --home "$HOMEDIR"
-# polard genesis add-genesis-account faucet 1000000000000000000000000000abera,1000000000000000000000000000stgusdc --keyring-backend $KEYRING --home "$HOMEDIR"
-
-# # # Test Account
-# # absurd surge gather author blanket acquire proof struggle runway attract cereal quiz tattoo shed almost sudden survey boring film memory picnic favorite verb tank
-# # 0xfffdbb37105441e14b0ee6330d855d8504ff39e705c3afa8f859ac9865f99306
-# polard genesis add-genesis-account cosmos1yrene6g2zwjttemf0c65fscg8w8c55w58yh8rl 1000000000000000000000000000abera,1000000000000000000000000000stgusdc --keyring-backend $KEYRING --home "$HOMEDIR"
+MONIKER=$1
+sed -i "s/^moniker = .*/moniker = \"$MONIKER\"/" "$CONFIG_TOML"


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the initialization script in `e2e/testapp/docker/seed/scripts/seed0-init-step2.sh` to directly use `/.polard` as the home directory path, enhancing the script's simplicity and readability.
- Chore: Added a license header to `e2e/testapp/docker/seed/scripts/set-moniker.sh` for legal compliance.
- Bug Fix: Modified the `sed` command in `set-moniker.sh` to correctly replace the `moniker` value in the configuration file, improving the script's functionality and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->