### PR TITLE
fix(sdb): CreateAccount should check for existence before creating. 

### DIFF
--- a/cosmos/x/evm/plugins/state/plugin.go
+++ b/cosmos/x/evm/plugins/state/plugin.go
@@ -206,7 +206,10 @@ func (p *plugin) Finalize() {
 // CreateAccount implements the `StatePlugin` interface by creating a new account
 // in the account keeper. It will allow accounts to be overridden.
 func (p *plugin) CreateAccount(addr common.Address) {
-	acc := p.ak.NewAccountWithAddress(p.ctx, addr[:])
+	acc := p.ak.GetAccount(p.ctx, addr[:])
+	if acc == nil {
+		acc = p.ak.NewAccountWithAddress(p.ctx, addr[:])
+	}
 
 	// save the new account in the account keeper
 	p.ak.SetAccount(p.ctx, acc)

--- a/e2e/testapp/docker/docker-compose.yml
+++ b/e2e/testapp/docker/docker-compose.yml
@@ -94,6 +94,7 @@ services:
         ipv4_address: 192.168.10.13
 
   nginx:
+    depends_on: [ node0, node1, node2, node3 ]
     container_name: nginx
     image: nginx:latest
     ports:


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- New Feature: Enhanced account creation process in our system. Now, if you attempt to create an account with an address that already exists, the system will automatically update the existing account instead of generating an error. This change streamlines the account management process, making it more efficient and user-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->