### PR TITLE
chore(test): fix typo in contracts/src/testing/DistributionWrapper.sol

### DIFF
--- a/contracts/src/testing/DistributionWrapper.sol
+++ b/contracts/src/testing/DistributionWrapper.sol
@@ -60,7 +60,7 @@ contract DistributionWrapper {
     }
 
     /**
-     * @dev Withdraw the rewrads accumilated by the caller(msg.sender).
+     * @dev Withdraw the rewrads accumulated by the caller(msg.sender).
      * @param _withdrawAddress The address of the delegator.
      */
     function setWithdrawAddress(address _withdrawAddress) external returns (bool) {
@@ -68,7 +68,7 @@ contract DistributionWrapper {
     }
 
     /**
-     * @dev Withdraw the rewrads accumilated by the caller(msg.sender).
+     * @dev Withdraw the rewrads accumulated by the caller(msg.sender).
      * @param _delegatorAddress The address of the delegator.
      * @param _validatorAddress The address of the validator.
      */
@@ -77,7 +77,7 @@ contract DistributionWrapper {
     }
 
     /**
-     * @dev Withdraw the rewrads accumilated by the caller(msg.sender).
+     * @dev Withdraw the rewrads accumulated by the caller(msg.sender).
      * @param _validator The address of the validator.
      */
     function delegate(address _validator) external payable {


### PR DESCRIPTION
fix typo in contracts/src/testing/DistributionWrapper.sol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Documentation: Corrected typographical errors in the comments of the `DistributionWrapper` contract. The term "accumulated" was misspelled as "accumilated" and has now been fixed. This change improves the readability and understanding of the code documentation for developers and other stakeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->