### PR TITLE
chore(actions): bump setup-go

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,9 +42,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -81,9 +83,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -122,24 +126,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
+
       - name: Download image artifact
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.base-image }}
       - name: Load image
         run: docker load -i ${{ matrix.base-image }}.tar
-      - name: Cache Golang Deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
       - name: Run `make test-hive`
         run: make hive-setup test-hive
         env:
@@ -158,24 +156,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
       - name: Download image artifact
         uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.base-image }}
       - name: Load image
         run: docker load -i ${{ matrix.base-image }}.tar
-      - name: Cache Golang Deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
       - name: Run ${{ matrix.namespace }}
         run: make test-${{ matrix.namespace }}
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,18 +40,12 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Cache Golang Deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
+          check-latest: true
+          cache-dependency-path: "**/*.sum"
+          
       - name: Run ${{ matrix.args }}
         run: |
           make ${{ matrix.args }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Chores:
- Updated the `actions/setup-go` action from version 3 to version 4 in our GitHub Actions workflows, ensuring we're using the latest features and improvements.
- Added the `check-latest` option to the `setup-go` action, which will ensure we're always using the latest version of Go.
- Implemented a new `cache-dependency-path` option in the `setup-go` action, improving the efficiency of our workflows by caching dependencies.
- Removed the `actions/cache` step for caching Golang dependencies, as this is now handled by the `setup-go` action, simplifying our workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->