### PR TITLE
refactor(x/evm): move precommit to end block 

### DIFF
--- a/cosmos/x/evm/keeper/abci.go
+++ b/cosmos/x/evm/keeper/abci.go
@@ -28,7 +28,7 @@ import (
 )
 
 // Precommit runs on the Cosmo-SDK lifecycle Precommit().
-func (k *Keeper) Precommit(ctx context.Context) error {
+func (k *Keeper) EndBlock(ctx context.Context) error {
 	// Verify that the EVM block was written.
 	// TODO: Set/GetHead to set and get the canonical head.
 	blockNum := uint64(sdk.UnwrapSDKContext(ctx).BlockHeight())

--- a/cosmos/x/evm/module.go
+++ b/cosmos/x/evm/module.go
@@ -45,7 +45,7 @@ const ConsensusVersion = 1
 var (
 	_ appmodule.HasServices          = AppModule{}
 	_ appmodule.HasPrepareCheckState = AppModule{}
-	_ appmodule.HasPrecommit         = AppModule{}
+	_ appmodule.HasEndBlocker        = AppModule{}
 	_ module.AppModule               = AppModule{}
 	_ module.AppModuleBasic          = AppModuleBasic{}
 )
@@ -132,6 +132,6 @@ func (am AppModule) PrepareCheckState(ctx context.Context) error {
 }
 
 // Precommit performs precommit operations.
-func (am AppModule) Precommit(ctx context.Context) error {
-	return am.keeper.Precommit(ctx)
+func (am AppModule) EndBlock(ctx context.Context) error {
+	return am.keeper.EndBlock(ctx)
 }

--- a/e2e/testapp/app_config.go
+++ b/e2e/testapp/app_config.go
@@ -138,13 +138,11 @@ func MakeAppConfig(bech32Prefix string) depinject.Config {
 						genutiltypes.ModuleName,
 					},
 					EndBlockers: []string{
+						evmtypes.ModuleName,
 						crisistypes.ModuleName,
 						govtypes.ModuleName,
 						stakingtypes.ModuleName,
 						genutiltypes.ModuleName,
-					},
-					Precommiters: []string{
-						evmtypes.ModuleName,
 					},
 					OverrideStoreKeys: []*runtimev1alpha1.StoreKeyConfig{
 						{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- The `Precommit` function in the `Keeper` struct and `AppModule` has been renamed to `EndBlock`, maintaining the same functionality and error return type. This change is part of an internal code restructuring and should not affect end-user experience.

Chores:
- The EVM module has been moved from the `Precommiters` list to the `EndBlockers` list in the `MakeAppConfig` function. This is a backend adjustment and should not impact the end-user directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->