### PR TITLE
fix(mempool): allow sdk.Tx's to not fail `checkTx`

### DIFF
--- a/cosmos/runtime/txpool/mempool.go
+++ b/cosmos/runtime/txpool/mempool.go
@@ -102,7 +102,8 @@ func (m *Mempool) Insert(ctx context.Context, sdkTx sdk.Tx) error {
 	}
 
 	if wet, ok := utils.GetAs[*types.WrappedEthereumTransaction](msgs[0]); !ok {
-		return errors.New("only WrappedEthereumTransactions are supported")
+		// We have to return nil for non-ethereum transactions as to not fail check-tx.
+		return nil
 	} else if errs := m.txpool.Add(
 		[]*coretypes.Transaction{wet.Unwrap()}, false, false,
 	); len(errs) != 0 {

--- a/cosmos/runtime/txpool/mempool_test.go
+++ b/cosmos/runtime/txpool/mempool_test.go
@@ -81,9 +81,9 @@ var _ = Describe("", func() {
 			})
 		})
 		When("we use an that is not an ethereum msg", func() {
-			It("errors", func() {
+			It("does not error", func() {
 				sdkTx.On("GetMsgs").Return([]sdk.Msg{nil}).Once()
-				Expect(mempool.Insert(ctx, sdkTx)).To(HaveOccurred())
+				Expect(mempool.Insert(ctx, sdkTx)).ToNot(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
this is bad but required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for transaction processing, allowing for smoother handling of non-Ethereum transactions.

- **Tests**
  - Updated test cases to reflect new behavior in transaction processing, ensuring non-Ethereum transactions are accepted without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->