### PR TITLE
fix: fix the wrong description about `polard` binary

### DIFF
--- a/e2e/testapp/polard/cmd/root.go
+++ b/e2e/testapp/polard/cmd/root.go
@@ -88,8 +88,8 @@ func NewRootCmd() *cobra.Command {
 	ethcryptocodec.RegisterInterfaces(clientCtx.InterfaceRegistry)
 
 	rootCmd := &cobra.Command{
-		Use:           "simd",
-		Short:         "simulation app",
+		Use:           "polard",
+		Short:         "node daemon and CLI for interacting with a polaris node",
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			var err error


### PR DESCRIPTION
Currently, run `make` will generate a `polard` binary under ./build/bin/, and run `polard --help` will show the wrong description

![image](https://github.com/berachain/polaris/assets/30857671/dee6f749-4757-42ee-a11a-bc8b979b470a)

This pr fix this

![image](https://github.com/berachain/polaris/assets/30857671/97558c36-1375-4a6a-84d3-ef6beb9a54d4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the command-line interface naming and description to reflect the Polaris node daemon and interaction capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->