### PR TITLE
fix(eth): Fix issue with validateArg() under certain scenarios

### DIFF
--- a/eth/core/precompile/method_validation.go
+++ b/eth/core/precompile/method_validation.go
@@ -40,6 +40,13 @@ func validateArg(implMethodVar reflect.Value, abiMethodVar reflect.Value) error 
 
 	switch implMethodVarType.Kind() { //nolint:exhaustive // todo verify its okay.
 	case reflect.Array, reflect.Slice:
+		// abiMethodVarType is not also a slice or array
+		if abiMethodVarType.Kind() != reflect.Array && abiMethodVarType.Kind() != reflect.Slice {
+			return fmt.Errorf(
+				"type mismatch: %v != %v", implMethodVarType, abiMethodVarType,
+			)
+		}
+
 		if implMethodVarType.Elem() != abiMethodVarType.Elem() {
 			// If the array is not a slice/array of structs, return an error.
 			if implMethodVarType.Elem().Kind() != reflect.Struct {

--- a/eth/core/precompile/method_validation_test.go
+++ b/eth/core/precompile/method_validation_test.go
@@ -62,6 +62,15 @@ var _ = Describe("Method", func() {
 	})
 
 	Context("validateArg", func() {
+		It("should error when array and scalar mismatch", func() {
+			sliceA := []uint64{0}
+			sliceB := uint64(0)
+			Expect(validateArg(
+				reflect.ValueOf(sliceA),
+				reflect.ValueOf(sliceB)).Error()).To(Equal(
+				"type mismatch: []uint64 != uint64",
+			))
+		})
 		It("should error when struct fields aren't the same", func() {
 			sliceA := []mockStruct{}
 			sliceB := []mockStructBad{}


### PR DESCRIPTION
Certain overloaded solidity functions in precompiles can cause `validateArg()` to panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced validation for argument types in smart contract methods to prevent mismatches, ensuring that arrays and slices are correctly checked for type consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->