### PR TITLE
fix: Add check len msgs when process proposal

### DIFF
--- a/cosmos/runtime/chain/abci.go
+++ b/cosmos/runtime/chain/abci.go
@@ -51,10 +51,12 @@ func (wbc *WrappedBlockchain) ProcessProposal(
 			continue
 		}
 
-		protoEnvelope := sdkTx.GetMsgs()[0]
-		if env, ok := protoEnvelope.(*evmtypes.WrappedPayloadEnvelope); ok {
-			envelope = env.UnwrapPayload()
-			break
+		if len(sdkTx.GetMsgs()) == 1 {
+			protoEnvelope := sdkTx.GetMsgs()[0]
+			if env, ok := protoEnvelope.(*evmtypes.WrappedPayloadEnvelope); ok {
+				envelope = env.UnwrapPayload()
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved transaction message processing by ensuring at exactly one message is present before unwrapping the payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->