### PR TITLE
Fix: Error Handling for Commit Length in Miner Configuration

### DIFF
--- a/cosmos/config/config.go
+++ b/cosmos/config/config.go
@@ -21,6 +21,7 @@
 package config
 
 import (
+	"fmt"
 	"math/big"
 
 	"github.com/berachain/polaris/cosmos/config/flags"
@@ -106,7 +107,7 @@ func readConfigFromAppOptsParser(parser AppOptionsParser) (*Config, error) {
 	if len(conf.Polar.Miner.ExtraData) == 0 {
 		commit := version.NewInfo().GitCommit
 		if len(commit) != 40 { //nolint:gomnd // its okay.
-			return nil, err
+			return nil, fmt.Errorf("invalid git commit length: %d", len(commit))
 		}
 		conf.Polar.Miner.ExtraData = hexutil.Bytes(
 			commit[32:40],


### PR DESCRIPTION
## Bug:
The function incorrectly returns nil when the Git commit length is not equal to 40, potentially causing unclear failures.

## Fix:
Correct the error handling to return a specific error when the commit length check fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated configuration validation to ensure the git commit length is correctly verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->