### PR TITLE
fix(evict): Switch to LRU to prevent removed transactions from being re-gossiped from a peer instantly.

### DIFF
--- a/cosmos/runtime/txpool/ante.go
+++ b/cosmos/runtime/txpool/ante.go
@@ -53,7 +53,6 @@ func (m *Mempool) AnteHandle(
 			if shouldEject := m.shouldEjectFromCometMempool(
 				ctx.BlockTime().Unix(), ethTx,
 			); shouldEject {
-				m.crc.DropRemoteTx(ethTx.Hash())
 				telemetry.IncrCounter(float32(1), MetricKeyAnteEjectedTxs)
 				return ctx, errors.New("eject from comet mempool")
 			}

--- a/cosmos/runtime/txpool/comet.go
+++ b/cosmos/runtime/txpool/comet.go
@@ -35,7 +35,7 @@ const (
 // Comet CheckTX and when.
 type CometRemoteCache interface {
 	IsRemoteTx(txHash common.Hash) bool
-	MarkRemoteSeen(txHash common.Hash)
+	MarkRemoteSeen(txHash common.Hash) bool
 	TimeFirstSeen(txHash common.Hash) int64 // Unix timestamp
 }
 
@@ -56,8 +56,12 @@ func (crc *cometRemoteCache) IsRemoteTx(txHash common.Hash) bool {
 }
 
 // Record the time the tx was inserted from Comet successfully.
-func (crc *cometRemoteCache) MarkRemoteSeen(txHash common.Hash) {
-	crc.timeInserted.Add(txHash, time.Now().Unix())
+func (crc *cometRemoteCache) MarkRemoteSeen(txHash common.Hash) bool {
+	if !crc.timeInserted.Contains(txHash) {
+		crc.timeInserted.Add(txHash, time.Now().Unix())
+		return true
+	}
+	return false
 }
 
 func (crc *cometRemoteCache) TimeFirstSeen(txHash common.Hash) int64 {

--- a/cosmos/runtime/txpool/mempool.go
+++ b/cosmos/runtime/txpool/mempool.go
@@ -140,7 +140,7 @@ func (m *Mempool) Insert(ctx context.Context, sdkTx sdk.Tx) error {
 	}
 
 	// Add the eth tx to the remote cache.
-	m.crc.MarkRemoteSeen(ethTx.Hash())
+	_ = m.crc.MarkRemoteSeen(ethTx.Hash())
 
 	return nil
 }
@@ -157,6 +157,6 @@ func (m *Mempool) Select(context.Context, [][]byte) mempool.Iterator {
 }
 
 // Remove is an intentional no-op as the eth txpool handles removals.
-func (m *Mempool) Remove(tx sdk.Tx) error {
+func (m *Mempool) Remove(_ sdk.Tx) error {
 	return nil
 }

--- a/cosmos/runtime/txpool/mempool.go
+++ b/cosmos/runtime/txpool/mempool.go
@@ -172,10 +172,6 @@ func (m *Mempool) Remove(tx sdk.Tx) error {
 			if err := ethTx.UnmarshalBinary(txBz); err != nil {
 				continue
 			}
-			txHash := ethTx.Hash()
-
-			// Remove the eth tx from comet seen tx cache.
-			m.crc.DropRemoteTx(txHash)
 		}
 	}
 	return nil

--- a/cosmos/runtime/txpool/mempool.go
+++ b/cosmos/runtime/txpool/mempool.go
@@ -158,21 +158,5 @@ func (m *Mempool) Select(context.Context, [][]byte) mempool.Iterator {
 
 // Remove is an intentional no-op as the eth txpool handles removals.
 func (m *Mempool) Remove(tx sdk.Tx) error {
-	// Get the Eth payload envelope from the Cosmos transaction.
-	msgs := tx.GetMsgs()
-	if len(msgs) == 1 {
-		env, ok := utils.GetAs[*types.WrappedPayloadEnvelope](msgs[0])
-		if !ok {
-			return nil
-		}
-
-		// Unwrap the payload to unpack the individual eth transactions to remove from the txpool.
-		for _, txBz := range env.UnwrapPayload().ExecutionPayload.Transactions {
-			ethTx := new(ethtypes.Transaction)
-			if err := ethTx.UnmarshalBinary(txBz); err != nil {
-				continue
-			}
-		}
-	}
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved transaction handling efficiency in the network.
- **Performance Improvements**
	- Enhanced cache management for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->