### PR TITLE
docs: license typo fix

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/hive/clients/polard/entrypoint.sh
+++ b/e2e/hive/clients/polard/entrypoint.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/localnet/network/fixture.go
+++ b/e2e/localnet/network/fixture.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/localnet/utils/utils.go
+++ b/e2e/localnet/utils/utils.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/precompile/polard/start-node.sh
+++ b/e2e/precompile/polard/start-node.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/LICENSE.header
+++ b/e2e/testapp/LICENSE.header
@@ -1,7 +1,7 @@
 SPDX-License-Identifier: BUSL-1.1
 
 Copyright (C) 2023, Berachain Foundation. All rights reserved.
-Use of this software is govered by the Business Source License included 
+Use of this software is governed by the Business Source License included
 in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 
 ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/app.go
+++ b/e2e/testapp/app.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/app_config.go
+++ b/e2e/testapp/app_config.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/docker-compose.yml
+++ b/e2e/testapp/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/local/docker-init.sh
+++ b/e2e/testapp/docker/local/docker-init.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/network-init-4.sh
+++ b/e2e/testapp/docker/network-init-4.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/reset-temp.sh
+++ b/e2e/testapp/docker/reset-temp.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/init.sh
+++ b/e2e/testapp/docker/seed/init.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/get-seed-address.sh
+++ b/e2e/testapp/docker/seed/scripts/get-seed-address.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/liveness-probe.sh
+++ b/e2e/testapp/docker/seed/scripts/liveness-probe.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/readiness-probe.sh
+++ b/e2e/testapp/docker/seed/scripts/readiness-probe.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/reset.sh
+++ b/e2e/testapp/docker/seed/scripts/reset.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/seed-start.sh
+++ b/e2e/testapp/docker/seed/scripts/seed-start.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/seed0-init-step1.sh
+++ b/e2e/testapp/docker/seed/scripts/seed0-init-step1.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/seed0-init-step2.sh
+++ b/e2e/testapp/docker/seed/scripts/seed0-init-step2.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/seed1-init-step1.sh
+++ b/e2e/testapp/docker/seed/scripts/seed1-init-step1.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/seed1-init-step2.sh
+++ b/e2e/testapp/docker/seed/scripts/seed1-init-step2.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/set-moniker.sh
+++ b/e2e/testapp/docker/seed/scripts/set-moniker.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/set-persistent-peers.sh
+++ b/e2e/testapp/docker/seed/scripts/set-persistent-peers.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/seed/scripts/set-seed-address.sh
+++ b/e2e/testapp/docker/seed/scripts/set-seed-address.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/validator/scripts/create-val.sh
+++ b/e2e/testapp/docker/validator/scripts/create-val.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/validator/scripts/val0-init-step1.sh
+++ b/e2e/testapp/docker/validator/scripts/val0-init-step1.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/validator/scripts/val0-init-step2.sh
+++ b/e2e/testapp/docker/validator/scripts/val0-init-step2.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/validator/scripts/val0-init-step3.sh
+++ b/e2e/testapp/docker/validator/scripts/val0-init-step3.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/validator/scripts/val1-init-step1.sh
+++ b/e2e/testapp/docker/validator/scripts/val1-init-step1.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/docker/validator/scripts/val1-init-step2.sh
+++ b/e2e/testapp/docker/validator/scripts/val1-init-step2.sh
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/entrypoint.sh
+++ b/e2e/testapp/entrypoint.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 #
 # Copyright (C) 2023, Berachain Foundation. All rights reserved.
-# Use of this software is govered by the Business Source License included
+# Use of this software is governed by the Business Source License included
 # in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 #
 # ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/export.go
+++ b/e2e/testapp/export.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/helpers.go
+++ b/e2e/testapp/helpers.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/polard/cmd/commands.go
+++ b/e2e/testapp/polard/cmd/commands.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/polard/cmd/root.go
+++ b/e2e/testapp/polard/cmd/root.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/polard/cmd/root_test.go
+++ b/e2e/testapp/polard/cmd/root_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/polard/main.go
+++ b/e2e/testapp/polard/main.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/e2e/testapp/upgrades.go
+++ b/e2e/testapp/upgrades.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/LICENSE.header
+++ b/eth/LICENSE.header
@@ -1,7 +1,7 @@
 SPDX-License-Identifier: BUSL-1.1
 
 Copyright (C) 2023, Berachain Foundation. All rights reserved.
-Use of this software is govered by the Business Source License included 
+Use of this software is governed by the Business Source License included
 in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 
 ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain.go
+++ b/eth/core/chain.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_context.go
+++ b/eth/core/chain_context.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_genesis.go
+++ b/eth/core/chain_genesis.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_helpers.go
+++ b/eth/core/chain_helpers.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_reader.go
+++ b/eth/core/chain_reader.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_resources.go
+++ b/eth/core/chain_resources.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_subscriber.go
+++ b/eth/core/chain_subscriber.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/chain_writer.go
+++ b/eth/core/chain_writer.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/core_test.go
+++ b/eth/core/core_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/errors.go
+++ b/eth/core/errors.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/genesis.go
+++ b/eth/core/genesis.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/host.go
+++ b/eth/core/host.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/mock/aliases.go
+++ b/eth/core/mock/aliases.go
@@ -1,6 +1,6 @@
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/mock/block_plugin.go
+++ b/eth/core/mock/block_plugin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/mock/historical_plugin.go
+++ b/eth/core/mock/historical_plugin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/mock/precompile_plugin.go
+++ b/eth/core/mock/precompile_plugin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/mock/state_plugin.go
+++ b/eth/core/mock/state_plugin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/base_contract.go
+++ b/eth/core/precompile/base_contract.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/default_plugin.go
+++ b/eth/core/precompile/default_plugin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/errors.go
+++ b/eth/core/precompile/errors.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/factories.go
+++ b/eth/core/precompile/factories.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/factories_test.go
+++ b/eth/core/precompile/factories_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/interfaces.go
+++ b/eth/core/precompile/interfaces.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/method.go
+++ b/eth/core/precompile/method.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/method_helpers.go
+++ b/eth/core/precompile/method_helpers.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/method_test.go
+++ b/eth/core/precompile/method_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/method_validation_test.go
+++ b/eth/core/precompile/method_validation_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/mock/stateful_impl.go
+++ b/eth/core/precompile/mock/stateful_impl.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/precompile_test.go
+++ b/eth/core/precompile/precompile_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/stateful_container.go
+++ b/eth/core/precompile/stateful_container.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/precompile/stateful_container_test.go
+++ b/eth/core/precompile/stateful_container_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/interfaces.go
+++ b/eth/core/state/interfaces.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/access_list.go
+++ b/eth/core/state/journal/access_list.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/access_list_test.go
+++ b/eth/core/state/journal/access_list_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/base.go
+++ b/eth/core/state/journal/base.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/constants.go
+++ b/eth/core/state/journal/constants.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/journal_test.go
+++ b/eth/core/state/journal/journal_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/logs.go
+++ b/eth/core/state/journal/logs.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/logs_test.go
+++ b/eth/core/state/journal/logs_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/mock/state_plugin.go
+++ b/eth/core/state/journal/mock/state_plugin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/refund.go
+++ b/eth/core/state/journal/refund.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/refund_test.go
+++ b/eth/core/state/journal/refund_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/selfdestruct_test.go
+++ b/eth/core/state/journal/selfdestruct_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/selfdestructs.go
+++ b/eth/core/state/journal/selfdestructs.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/transient_storage.go
+++ b/eth/core/state/journal/transient_storage.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/journal/transient_storage_test.go
+++ b/eth/core/state/journal/transient_storage_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/mock/state.go
+++ b/eth/core/state/mock/state.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/modes.go
+++ b/eth/core/state/modes.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/statedb.go
+++ b/eth/core/state/statedb.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/state/statedb_test.go
+++ b/eth/core/state/statedb_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/types/header.go
+++ b/eth/core/types/header.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/types/receipts.go
+++ b/eth/core/types/receipts.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/types/transaction.go
+++ b/eth/core/types/transaction.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/types/types_test.go
+++ b/eth/core/types/types_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/vm/context.go
+++ b/eth/core/vm/context.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/vm/interfaces.go
+++ b/eth/core/vm/interfaces.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/vm/mock/evm.go
+++ b/eth/core/vm/mock/evm.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/core/vm/mock/statedb.go
+++ b/eth/core/vm/mock/statedb.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY

--- a/eth/eth.go
+++ b/eth/eth.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 // Copyright (C) 2023, Berachain Foundation. All rights reserved.
-// Use of this software is govered by the Business Source License included
+// Use of this software is governed by the Business Source License included
 // in the LICENSE file of this repository and at www.mariadb.com/bsl11.
 //
 // ANY USE OF THE LICENSED WORK IN VIOLATION OF THIS LICENSE WILL AUTOMATICALLY


### PR DESCRIPTION
Fixing typo in license. From "govered" to "governed".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected typographical errors in the license information across various files, ensuring the correct spelling of "governed" in license headers and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->