### PR TITLE
fix(miner): use unixnano for block time

### DIFF
--- a/cosmos/runtime/miner/miner.go
+++ b/cosmos/runtime/miner/miner.go
@@ -102,7 +102,7 @@ func (m *Miner) submitPayloadForBuilding(ctx context.Context) error {
 		err         error
 		payload     *miner.Payload
 		sCtx        = sdk.UnwrapSDKContext(ctx)
-		payloadArgs = m.constructPayloadArgs(uint64(sCtx.BlockTime().Unix()))
+		payloadArgs = m.constructPayloadArgs(uint64(sCtx.BlockTime().UnixNano()))
 	)
 
 	// Set the mining context for geth to build the payload with.


### PR DESCRIPTION
This PR updates the payload to use nano timestamp to allow sub-second block time. Fixes https://github.com/rollkit/rollkit/issues/1529