### PR TITLE
chore: fix typos

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -4,7 +4,7 @@
 
 <pre>
 🛜 e2e 🛜
-├── <a href="./hive">contracts</a>: Resources for runinng `ethereum/hive` e2e testing.
+├── <a href="./hive">contracts</a>: Resources for running `ethereum/hive` e2e testing.
 ├── <a href="./localnet">docs</a>: Running a `testapp` in a container for `e2e` testing.
 ├── <a href="./testapp">cosmos</a>: Example / Testing Polaris enabled Cosmos-SDk based chain.
 </pre>


### PR DESCRIPTION
fix a typo: `runinng`->`running`