### PR TITLE
fix(readme): add foundryup command after curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you want to help contribute to the framework, check out the [Framework Specs]
 2. Install Foundry:
 
    ```sh
-   curl -L https://foundry.paradigm.xyz | bash
+   curl -L https://foundry.paradigm.xyz | bash && foundryup
    ```
 
 3. Clone, Setup and Test:


### PR DESCRIPTION
Issue #1481

I ran into the same issue setting up, foundryup seems to always be needed to run after the curl

Description:
- Fix foundry install step